### PR TITLE
Update the README dependencies list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,13 +10,17 @@ the `H3 Documentation <https://uber.github.io/h3/>`__.
 Installing
 ==========
 
-You need to have a ``cc`` in your ``$PATH`` when installing this
+You need to have ``cc``, ``make``, and ``cmake`` in your ``$PATH`` when installing this
 package:
 
 .. code:: sh
 
     which cc
     /usr/bin/cc
+    which make
+    /usr/bin/make
+    which cmake
+    /usr/bin/cmake
 
 **Python 3.4+:**
 


### PR DESCRIPTION
This fixes an oversight found by @JCHHeilmann in issue #5 

For users that don't normally work with C/C++ code they might not have the relevant tools.

@isaacbrodsky should this dependency list be more precise as it seems the C H3 library is heading towards? (Specifying what install commands to run in different operating systems?)