### PR TITLE
Use the version number in the parity test

### DIFF
--- a/.test_parity.sh
+++ b/.test_parity.sh
@@ -11,3 +11,4 @@ rm -rf h3c
 git clone https://github.com/uber/h3.git h3c
 pushd h3c
 git pull origin master --tags
+git checkout "$VERSION"


### PR DESCRIPTION
This should unblock the build failure in #15 and #16. The version was already passed to this script, just needs to be used.