### PR TITLE
Fix subprocess api so that the install is backward compatible with python 2.7

### DIFF
--- a/h3/h3.py
+++ b/h3/h3.py
@@ -240,7 +240,7 @@ def h3_is_valid(h3_address):
     :returns: boolean
     """
     try:
-        return libh3.h3IsValid(string_to_h3(h3_address)) is 1
+        return libh3.h3IsValid(string_to_h3(h3_address)) == 1
     except Exception:
         return False
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Testing
-pytest>=2.7
+pytest==4.0.2
 pytest-cov==1.8.1
 coverage==3.7.1
 mock==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ from binding_version import binding_version
 
 
 def install_h3(h3_version):
-    subprocess.run(
-        'bash ./.install.sh {}'.format(h3_version), shell=True, check=True)
+    subprocess.call('bash ./.install.sh {}'.format(h3_version), shell=True)
+    #subprocess.run(
+    #    'bash ./.install.sh {}'.format(h3_version), shell=True, check=True)
 
 
 class CustomBuildExtCommand(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ from binding_version import binding_version
 
 def install_h3(h3_version):
     subprocess.call('bash ./.install.sh {}'.format(h3_version), shell=True)
-    #subprocess.run(
-    #    'bash ./.install.sh {}'.format(h3_version), shell=True, check=True)
 
 
 class CustomBuildExtCommand(build_ext):


### PR DESCRIPTION
Fix subprocess api so that the install is backward compatible with python 2.7