### PR TITLE
fail fast if install script met error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from binding_version import binding_version
 
 
 def install_h3(h3_version):
-    subprocess.call('bash ./.install.sh {}'.format(h3_version), shell=True)
+    subprocess.check_call('bash ./.install.sh {}'.format(h3_version), shell=True)
 
 
 class CustomBuildExtCommand(build_ext):


### PR DESCRIPTION
Tested locally by uninstall make and rerun bootstrap.

Previous version won't return error but instead showing finished install h3 library.
After this change, it will show error
`subprocess.CalledProcessError: Command 'bash ./.install.sh v3.4.2' returned non-zero exit status 126`