### PR TITLE
Show missing dependency error to user for all OS types

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -9,6 +9,10 @@ if [ "" == "$VERSION" ]; then
     exit 1
 fi
 
+command -v cmake  >/dev/null 2>&1 || { echo "cmake required but not found."; exit 1; }
+command -v make  >/dev/null 2>&1 || { echo "make required but not found."; exit 1; }
+command -v cc  >/dev/null 2>&1 || { echo "cc required but not found."; exit 1; }
+
 mkdir -p h3/out
 rm -rf h3c
 git clone https://github.com/uber/h3.git h3c
@@ -17,27 +21,7 @@ pushd h3c
 git pull origin master --tags
 git checkout "$VERSION"
 
-# Run CMake, installing a recent version if not found or not compatible
-{
-	cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
-} || {
-	machineName=`uname -s`
-	if [ "$machineName" =~ "Linux.*" ]; then
-	  # Install modern CMake
-          mkdir cmake-download
-          pushd cmake-download
-          curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
-          bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license
-          export PATH=`pwd`/bin:$PATH
-          echo $PATH
-          popd
-          cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
-	else
-	  echo "Failed to find cmake. Please make sure cmake is installed and set in PATH."
-	  exit 1
-	fi
-}
-
+cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
 make
 ls -l lib/libh3*
 cp lib/libh3* ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -21,15 +21,21 @@ git checkout "$VERSION"
 {
 	cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
 } || {
-	# Install modern CMake
-	mkdir cmake-download
-	pushd cmake-download
-	curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
-	bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license
-	export PATH=`pwd`/bin:$PATH
-	echo $PATH
-	popd
-	cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
+	machineName=`uname -s`
+	if [ "$machineName" =~ "Linux.*" ]; then
+	  # Install modern CMake
+          mkdir cmake-download
+          pushd cmake-download
+          curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
+          bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license
+          export PATH=`pwd`/bin:$PATH
+          echo $PATH
+          popd
+          cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
+	else
+	  echo "Failed to find cmake. Please make sure cmake is installed and set in PATH."
+	  exit 1
+	fi
 }
 
 make

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from binding_version import binding_version
 
 
 def install_h3(h3_version):
-    subprocess.check_call('bash ./.install.sh {}'.format(h3_version), shell=True)
+    subprocess.call('bash ./.install.sh {}'.format(h3_version), shell=True)
 
 
 class CustomBuildExtCommand(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from binding_version import binding_version
 
 
 def install_h3(h3_version):
-    subprocess.call('bash ./.install.sh {}'.format(h3_version), shell=True)
+    subprocess.check_call('bash ./.install.sh {}'.format(h3_version), shell=True)
 
 
 class CustomBuildExtCommand(build_ext):


### PR DESCRIPTION
The linux version of cmake does not work on OSX environment. So adding a machine type check here, if machine type is Darwin, then don't install cmake but return error to user.

Not sure how Windows platform should work so not checking windows platform.

Tested by uninstall cmake and run install script. It will show error message
`Failed to find cmake. Please make sure cmake is installed and set in PATH.`