### PR TITLE
Windows build

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_C_FLAGS='"/MT"' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_C_FLAGS='"/MT"' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_C_FLAGS='/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='\/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_C_FLAGS='/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='\/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && cmake --build . --target h3 --config Release;
   else
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} && cmake --build . --target h3 --config Release;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.dll ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -48,7 +48,7 @@ else
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
-  cp bin/Release/h3.lib ../h3/out
+  cp bin/Release/h3.dll ../h3/out
 fi
 popd
 rm -rf h3c

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_C_FLAGS='\/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='\MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_C_FLAGS='\/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='\MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -3,6 +3,7 @@
 set -ex
 
 VERSION=$1
+IS_64BITS=$2
 
 if [ "" == "$VERSION" ]; then
     echo "Failed to specify version required"
@@ -35,7 +36,7 @@ if [ "Windows_NT" != "$OS" ]; then
   fi
 else
   # Assumed to be Windows, default to x86
-  if [[ "$PYTHON_ARCH" == "64" ]]; then
+  if [[ "True" == "$IS_64BITS" ]]; then
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 Win64"
   else
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_C_FLAGS='\MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='"/MT"' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_C_FLAGS='\MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='"/MT"' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -42,10 +42,10 @@ if command -v make; then
       cp lib/libh3* ../build/$LIBNAME/h3/out
   fi
 else
-  if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && cmake --build . --target h3 --config Release;
+  if [[ "$PYTHON_ARCH" == "64" ]]; then
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=$PLATFORM -G "Visual Studio 14 Win64" && cmake --build . --target h3 --config Release;
   else
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} && cmake --build . --target h3 --config Release;
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=$PLATFORM && cmake --build . --target h3 --config Release;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.dll ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_C_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_CXX_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_C_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_CXX_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -47,7 +47,7 @@ else
   else
     cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
-  ls -l bin/Release/h3*
+  ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out
 fi
 popd

--- a/.install.sh
+++ b/.install.sh
@@ -19,8 +19,9 @@ pushd h3c
 git pull origin master --tags
 git checkout "$VERSION"
 
-if command -v make; then
-  command -v cc  >/dev/null 2>&1 || { echo "cc required but not found."; exit 1; }
+if [ "Windows_NT" != "$OS" ]; then
+  command -v make >/dev/null 2>&1 || { echo "make required but not found."; exit 1; }
+  command -v cc >/dev/null 2>&1 || { echo "cc required but not found."; exit 1; }
 
   cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
 
@@ -33,11 +34,11 @@ if command -v make; then
       cp lib/libh3* ../build/$LIBNAME/h3/out
   fi
 else
-  # Assumed to be Windows, default to x64
-  if [[ "$PYTHON_ARCH" == "32" ]]; then
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=$PLATFORM
+  # Assumed to be Windows, default to x86
+  if [[ "$PYTHON_ARCH" == "64" ]]; then
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 Win64"
   else
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=$PLATFORM -G "Visual Studio 14 Win64"
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON
   fi
   cmake --build . --target h3 --config Release
   ls -l bin/Release/*

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.install.sh
+++ b/.install.sh
@@ -17,28 +17,38 @@ pushd h3c
 git pull origin master --tags
 git checkout "$VERSION"
 
-# Run CMake, installing a recent version if not found or not compatible
-{
-	cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
-} || {
-	# Install modern CMake
-	mkdir cmake-download
-	pushd cmake-download
-	curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
-	bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license
-	export PATH=`pwd`/bin:$PATH
-	echo $PATH
-	popd
-	cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
-}
+if command -v make; then
+  # Run CMake, installing a recent version if not found or not compatible
+  {
+    cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
+  } || {
+    # Install modern CMake
+    mkdir cmake-download
+    pushd cmake-download
+    curl -O https://cmake.org/files/v3.10/cmake-3.10.0-rc5-Linux-x86_64.sh
+    bash cmake-3.10.0-rc5-Linux-x86_64.sh --skip-license
+    export PATH=`pwd`/bin:$PATH
+    echo $PATH
+    popd
+    cmake -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON .
+  }
 
-make
-ls -l lib/libh3*
-cp lib/libh3* ../h3/out
-if [ -e ../build ] && [ -d ../build ]; then
-    LIBNAME=`ls ../build/ | grep '^lib'`
-    mkdir -p ../build/$LIBNAME/h3/out
-    cp lib/libh3* ../build/$LIBNAME/h3/out
+  make
+  ls -l lib/libh3*
+  cp lib/libh3* ../h3/out
+  if [ -e ../build ] && [ -d ../build ]; then
+      LIBNAME=`ls ../build/ | grep '^lib'`
+      mkdir -p ../build/$LIBNAME/h3/out
+      cp lib/libh3* ../build/$LIBNAME/h3/out
+  fi
+else
+  if [[ "${Platform}" == "x64" ]]; then
+    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+  else
+    cmake . -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+  fi
+  ls -l bin/Release/h3*
+  cp bin/Release/h3.lib ../h3/out
 fi
 popd
 rm -rf h3c

--- a/.install.sh
+++ b/.install.sh
@@ -43,9 +43,9 @@ if command -v make; then
   fi
 else
   if [[ "${Platform}" == "x64" ]]; then
-    cmake . -DCMAKE_CXX_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} -G "Visual Studio 14 Win64" && msbuild.exe h3.vcxproj;
   else
-    cmake . -DCMAKE_CXX_FLAGS="/MT" -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
+    cmake . -DCMAKE_C_FLAGS='/MT' -DCMAKE_VS_PLATFORM_NAME=${Platform} && msbuild.exe h3.vcxproj;
   fi
   ls -l bin/Release/*
   cp bin/Release/h3.lib ../h3/out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-osx_image: xcode9.3
+osx_image: xcode8.3
 os:
 - osx
 - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 cache: pip
+osx_image: xcode9.3
 os:
 - osx
 - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 cache: pip
-osx_image: xcode8.3
 os:
-- osx
 - linux
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 cache: pip
+os:
+- osx
+- linux
 python:
+  - "2.7"
   - "3.6"
 install:
   - pip install -r requirements-dev.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ platform:
   - x64
 
 install:
-  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
   - pip install -r requirements-dev.txt
   - fab bootstrap
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+build: off
 environment:
   matrix:
     - PYTHON: "C:\\Python27"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+
+configuration: Release
+platform:
+  - x86
+  - x64
+
+install:
+  - SET PATH=C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin;%PATH%
+  - pip install -r requirements-dev.txt
+  - fab bootstrap
+
+test_script:
+  - python --version
+  - fab --version
+  - fab test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ platform:
   - x64
 
 install:
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - echo %PATH%
   - pip install -r requirements-dev.txt
   - fab bootstrap
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ environment:
 
 configuration: Release
 platform:
-  - x86
   - x64
 
 install:

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -38,6 +38,11 @@ libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
               if platform.system() == 'Darwin' else (
               '{}\\{}'.format(_dirname, 'out\\h3.lib') if platform.system() == 'Windows' else
               '{}/{}'.format(_dirname, 'out/libh3.so.1')))
+
+# Load the Windows version of libc for H3 to use (calloc, free, etc)
+if platform.system() == 'Windows':
+    ctypes.CDLL(ctypes.util.find_msvcrt())
+
 libh3 = cdll.LoadLibrary(libh3_path)
 
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -25,8 +25,9 @@ from ctypes import (
     cast,
     cdll,
     c_int,
-    c_long,
     c_double,
+    c_longlong,
+    c_ulonglong,
     c_void_p,
     byref,
     Structure,
@@ -41,6 +42,8 @@ libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
 
 libh3 = cdll.LoadLibrary(libh3_path)
 
+# Type of an H3 index
+H3Index = c_ulonglong
 
 class GeoCoord(Structure):
     """
@@ -115,25 +118,25 @@ LinkedGeoPolygon._fields_ = [('first', POINTER(LinkedGeoLoop)),
                              ('next', POINTER(LinkedGeoPolygon))]
 
 libh3.h3IsValid.restype = c_int
-libh3.h3IsValid.argtypes = [c_long]
+libh3.h3IsValid.argtypes = [H3Index]
 
-libh3.geoToH3.restype = c_long
+libh3.geoToH3.restype = H3Index
 libh3.geoToH3.argtypes = [c_void_p, c_int]
 
 libh3.h3ToGeo.restype = None
-libh3.h3ToGeo.argtypes = [c_long, c_void_p]
+libh3.h3ToGeo.argtypes = [H3Index, c_void_p]
 
 libh3.h3ToGeoBoundary.restype = None
-libh3.h3ToGeoBoundary.argtypes = [c_long, c_void_p]
+libh3.h3ToGeoBoundary.argtypes = [H3Index, c_void_p]
 
 libh3.maxKringSize.restype = c_int
 libh3.maxKringSize.argtypes = [c_int]
 
 libh3.kRing.restype = None
-libh3.kRing.argtypes = [c_long, c_int, c_void_p]
+libh3.kRing.argtypes = [H3Index, c_int, c_void_p]
 
 libh3.kRingDistances.restype = None
-libh3.kRingDistances.argtypes = [c_long, c_int, c_void_p, c_void_p]
+libh3.kRingDistances.argtypes = [H3Index, c_int, c_void_p, c_void_p]
 
 libh3.maxPolyfillSize.restype = c_int
 libh3.maxPolyfillSize.argtypes = [c_void_p, c_int]
@@ -148,7 +151,7 @@ libh3.destroyLinkedPolygon.restype = None
 libh3.destroyLinkedPolygon.argtypes = [c_void_p]
 
 libh3.hexRing.restype = c_int
-libh3.hexRing.argtypes = [c_long, c_int, c_void_p]
+libh3.hexRing.argtypes = [H3Index, c_int, c_void_p]
 
 libh3.compact.restype = c_int
 libh3.compact.argtypes = [c_void_p, c_void_p, c_int]
@@ -159,20 +162,20 @@ libh3.uncompact.argtypes = [c_void_p, c_int, c_void_p, c_int, c_int]
 libh3.maxUncompactSize.restype = c_int
 libh3.maxUncompactSize.argtypes = [c_void_p, c_int, c_int]
 
-libh3.h3ToParent.restype = c_long
-libh3.h3ToParent.argtypes = [c_long, c_int]
+libh3.h3ToParent.restype = H3Index
+libh3.h3ToParent.argtypes = [H3Index, c_int]
 
 libh3.maxH3ToChildrenSize.restype = c_int
-libh3.maxH3ToChildrenSize.argtypes = [c_long, c_int]
+libh3.maxH3ToChildrenSize.argtypes = [H3Index, c_int]
 
 libh3.h3ToChildren.restype = None
-libh3.h3ToChildren.argtypes = [c_long, c_int, c_void_p]
+libh3.h3ToChildren.argtypes = [H3Index, c_int, c_void_p]
 
 libh3.hexRange.restype = c_int
-libh3.hexRange.argtypes = [c_long, c_int, c_void_p]
+libh3.hexRange.argtypes = [H3Index, c_int, c_void_p]
 
 libh3.hexRangeDistances.restype = c_int
-libh3.hexRangeDistances.argtypes = [c_long, c_int, c_void_p, c_void_p]
+libh3.hexRangeDistances.argtypes = [H3Index, c_int, c_void_p, c_void_p]
 
 libh3.hexRanges.restype = c_int
 libh3.hexRanges.argtypes = [c_void_p, c_int, c_int, c_void_p]
@@ -189,44 +192,44 @@ libh3.edgeLengthKm.argtypes = [c_int]
 libh3.edgeLengthM.restype = c_double
 libh3.edgeLengthM.argtypes = [c_int]
 
-libh3.numHexagons.restype = c_long
+libh3.numHexagons.restype = c_longlong
 libh3.numHexagons.argtypes = [c_int]
 
 libh3.h3GetBaseCell.restype = c_int
-libh3.h3GetBaseCell.argtypes = [c_long]
+libh3.h3GetBaseCell.argtypes = [H3Index]
 
 libh3.h3IsResClassIII.restype = c_int
-libh3.h3IsResClassIII.argtypes = [c_long]
+libh3.h3IsResClassIII.argtypes = [H3Index]
 
 libh3.h3IsPentagon.restype = c_int
-libh3.h3IsPentagon.argtypes = [c_long]
+libh3.h3IsPentagon.argtypes = [H3Index]
 
 libh3.h3IndexesAreNeighbors.restype = c_int
-libh3.h3IndexesAreNeighbors.argtypes = [c_long, c_long]
+libh3.h3IndexesAreNeighbors.argtypes = [H3Index, H3Index]
 
-libh3.getH3UnidirectionalEdge.restype = c_long
-libh3.getH3UnidirectionalEdge.argtypes = [c_long, c_long]
+libh3.getH3UnidirectionalEdge.restype = H3Index
+libh3.getH3UnidirectionalEdge.argtypes = [H3Index, H3Index]
 
 libh3.h3UnidirectionalEdgeIsValid.restype = c_int
-libh3.h3UnidirectionalEdgeIsValid.argtypes = [c_long]
+libh3.h3UnidirectionalEdgeIsValid.argtypes = [H3Index]
 
-libh3.getOriginH3IndexFromUnidirectionalEdge.restype = c_long
-libh3.getOriginH3IndexFromUnidirectionalEdge.argtypes = [c_long]
+libh3.getOriginH3IndexFromUnidirectionalEdge.restype = H3Index
+libh3.getOriginH3IndexFromUnidirectionalEdge.argtypes = [H3Index]
 
-libh3.getDestinationH3IndexFromUnidirectionalEdge.restype = c_long
-libh3.getDestinationH3IndexFromUnidirectionalEdge.argtypes = [c_long]
+libh3.getDestinationH3IndexFromUnidirectionalEdge.restype = H3Index
+libh3.getDestinationH3IndexFromUnidirectionalEdge.argtypes = [H3Index]
 
 libh3.getH3IndexesFromUnidirectionalEdge.restype = None
-libh3.getH3IndexesFromUnidirectionalEdge.argtypes = [c_long, c_void_p]
+libh3.getH3IndexesFromUnidirectionalEdge.argtypes = [H3Index, c_void_p]
 
 libh3.getH3UnidirectionalEdgesFromHexagon.restype = None
-libh3.getH3UnidirectionalEdgesFromHexagon.argtypes = [c_long, c_void_p]
+libh3.getH3UnidirectionalEdgesFromHexagon.argtypes = [H3Index, c_void_p]
 
 libh3.getH3UnidirectionalEdgeBoundary.restype = None
-libh3.getH3UnidirectionalEdgeBoundary.argtypes = [c_long, c_void_p]
+libh3.getH3UnidirectionalEdgeBoundary.argtypes = [H3Index, c_void_p]
 
 libh3.h3Distance.restype = c_int
-libh3.h3Distance.argtypes = [c_long, c_long]
+libh3.h3Distance.argtypes = [H3Index, H3Index]
 
 
 def string_to_h3(h3_address):
@@ -321,7 +324,7 @@ def h3_to_geo_boundary(h3_address, geo_json=False):
 def k_ring(h3_address, ring_size):
     """Get K-Rings for a given hexagon"""
     array_len = libh3.maxKringSize(ring_size)
-    KringArray = c_long * array_len
+    KringArray = H3Index * array_len
     # Initializes to zeroes by default, don't need to force
     krings = KringArray()
     libh3.kRing(string_to_h3(h3_address), ring_size, krings)
@@ -331,7 +334,7 @@ def k_ring(h3_address, ring_size):
 def k_ring_distances(h3_address, ring_size):
     """Get K-Rings for a given hexagon properly split by ring"""
     array_len = libh3.maxKringSize(ring_size)
-    KringArray = c_long * array_len
+    KringArray = H3Index * array_len
     DistanceArray = c_int * array_len
     # Initializes to zeroes by default, don't need to force
     krings = KringArray()
@@ -401,7 +404,7 @@ def polyfill(geo_json, res, geo_json_conformant=False):
     """
     geo_json_lite = _geo_json_to_geo_json_lite(geo_json, geo_json_conformant)
     array_len = libh3.maxPolyfillSize(byref(geo_json_lite), res)
-    HexagonArray = c_long * array_len
+    HexagonArray = H3Index * array_len
     hexagons = HexagonArray()
     libh3.polyfill(byref(geo_json_lite), res, hexagons)
     return hexagon_c_array_to_set(hexagons)
@@ -423,7 +426,7 @@ def h3_set_to_multi_polygon(h3_addresses, geo_json=False):
         return []
     # Set up input set
     address_count = len(h3_addresses)
-    HexagonArray = c_long * address_count
+    HexagonArray = H3Index * address_count
     hexagons = HexagonArray()
     for i, address in enumerate(h3_addresses):
         hexagons[i] = int(address, 16)
@@ -488,7 +491,7 @@ def hex_ring(h3_address, ring_size):
     # This technically should be defined in the C code,
     # but this is much faster
     array_len = 6 * ring_size
-    HexRingArray = c_long * array_len
+    HexRingArray = H3Index * array_len
     hex_rings = HexRingArray()
     success = libh3.hexRing(string_to_h3(h3_address), ring_size, hex_rings)
     if success != 0:
@@ -503,7 +506,7 @@ def compact(h3_addresses):
         return set()
 
     num_hexagons = len(h3_addresses)
-    HexSetArray = c_long * num_hexagons
+    HexSetArray = H3Index * num_hexagons
     hex_set = HexSetArray()
     compacted_hex_set = HexSetArray()
     for i, address in enumerate(h3_addresses):
@@ -522,7 +525,7 @@ def uncompact(h3_addresses, res):
         return set()
 
     num_hexagons = len(h3_addresses)
-    HexSetArray = c_long * num_hexagons
+    HexSetArray = H3Index * num_hexagons
     hex_set = HexSetArray()
     for i, address in enumerate(h3_addresses):
         hex_set[i] = int(address, 16)
@@ -531,7 +534,7 @@ def uncompact(h3_addresses, res):
     if max_uncompacted_num < 0:
         raise Exception(
             'Failed to determine max uncompact output size (bad resolution?)')
-    HexOutSetArray = c_long * max_uncompacted_num
+    HexOutSetArray = H3Index * max_uncompacted_num
     uncompacted_hex_set = HexOutSetArray()
 
     ret_val = libh3.uncompact(hex_set, num_hexagons, uncompacted_hex_set,
@@ -550,7 +553,7 @@ def h3_to_parent(h3_address, res):
 def h3_to_children(h3_address, res):
     h3_address_num = string_to_h3(h3_address)
     max_children = libh3.maxH3ToChildrenSize(h3_address_num, res)
-    ChildrenArray = c_long * max_children
+    ChildrenArray = H3Index * max_children
     children = ChildrenArray()
     libh3.h3ToChildren(h3_address_num, res, children)
 
@@ -559,7 +562,7 @@ def h3_to_children(h3_address, res):
 
 def hex_range(h3_address, ring_size):
     array_len = libh3.maxKringSize(ring_size)
-    KringArray = c_long * array_len
+    KringArray = H3Index * array_len
     krings = KringArray()
     success = libh3.hexRange(string_to_h3(h3_address), ring_size, krings)
     if success != 0:
@@ -573,7 +576,7 @@ def hex_range_distances(h3_address, ring_size):
     aborting if a pentagon is reached
     """
     array_len = libh3.maxKringSize(ring_size)
-    KringArray = c_long * array_len
+    KringArray = H3Index * array_len
     DistanceArray = c_int * array_len
     # Initializes to zeroes by default, don't need to force
     krings = KringArray()
@@ -602,8 +605,8 @@ def hex_ranges(h3_address_list, ring_size):
     """
     num_hexagons = len(h3_address_list)
     array_len = num_hexagons * libh3.maxKringSize(ring_size)
-    HexArray = c_long * num_hexagons
-    KringArray = c_long * array_len
+    HexArray = H3Index * num_hexagons
+    KringArray = H3Index * array_len
     # Initializes to zeroes by default, don't need to force
     hex_array = HexArray(
         *[string_to_h3(h3_address) for h3_address in h3_address_list])
@@ -712,7 +715,7 @@ def get_destination_h3_index_from_unidirectional_edge(h3_address):
 
 
 def get_h3_indexes_from_unidirectional_edge(h3_address):
-    IndexArray = c_long * 2
+    IndexArray = H3Index * 2
     index_array = IndexArray()
     libh3.getH3IndexesFromUnidirectionalEdge(
         string_to_h3(h3_address), index_array)
@@ -722,7 +725,7 @@ def get_h3_indexes_from_unidirectional_edge(h3_address):
 
 
 def get_h3_unidirectional_edges_from_hexagon(h3_address):
-    IndexArray = c_long * 6
+    IndexArray = H3Index * 6
     index_array = IndexArray()
     libh3.getH3UnidirectionalEdgesFromHexagon(
         string_to_h3(h3_address), index_array)

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -34,11 +34,11 @@ from ctypes import (
 )
 
 _dirname = os.path.dirname(__file__)
-libh3_path = ('out/libh3.1.dylib'
+libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
               if platform.system() == 'Darwin' else (
-              'out/h3.lib' if platform.system() == 'Windows' else
-              'out/libh3.so.1'))
-libh3 = cdll.LoadLibrary('{}/{}'.format(_dirname, libh3_path))
+              '{}\\{}'.format(_dirname, 'out\\h3.lib') if platform.system() == 'Windows' else
+              '{}/{}'.format(_dirname, 'out/libh3.so.1')))
+libh3 = cdll.LoadLibrary(libh3_path)
 
 
 class GeoCoord(Structure):

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -39,10 +39,6 @@ libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
               '{}\\{}'.format(_dirname, 'out\\h3.dll') if platform.system() == 'Windows' else
               '{}/{}'.format(_dirname, 'out/libh3.so.1')))
 
-# Load the Windows version of libc for H3 to use (calloc, free, etc)
-# if platform.system() == 'Windows':
-#     cdll.LoadLibrary(ctypes_util.find_msvcrt())
-
 libh3 = cdll.LoadLibrary(libh3_path)
 
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -31,6 +31,7 @@ from ctypes import (
     byref,
     Structure,
     POINTER,
+    util as ctypes_util,
 )
 
 _dirname = os.path.dirname(__file__)
@@ -41,7 +42,7 @@ libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
 
 # Load the Windows version of libc for H3 to use (calloc, free, etc)
 if platform.system() == 'Windows':
-    ctypes.CDLL(ctypes.util.find_msvcrt())
+    cdll(ctypes_util.find_msvcrt())
 
 libh3 = cdll.LoadLibrary(libh3_path)
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -37,7 +37,7 @@ from ctypes import (
 _dirname = os.path.dirname(__file__)
 libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
               if platform.system() == 'Darwin' else (
-              '{}\\{}'.format(_dirname, 'out\\h3.dll') if platform.system() == 'Windows' else
+              '{}/{}'.format(_dirname, 'out/h3.dll') if platform.system() == 'Windows' else
               '{}/{}'.format(_dirname, 'out/libh3.so.1')))
 
 libh3 = cdll.LoadLibrary(libh3_path)

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -35,7 +35,9 @@ from ctypes import (
 
 _dirname = os.path.dirname(__file__)
 libh3_path = ('out/libh3.1.dylib'
-              if platform.system() == 'Darwin' else 'out/libh3.so.1')
+              if platform.system() == 'Darwin' else (
+              'out/h3.lib' if platform.system() == 'Windows' else
+              'out/libh3.so.1'))
 libh3 = cdll.LoadLibrary('{}/{}'.format(_dirname, libh3_path))
 
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -45,6 +45,7 @@ libh3 = cdll.LoadLibrary(libh3_path)
 # Type of an H3 index
 H3Index = c_ulonglong
 
+
 class GeoCoord(Structure):
     """
     An instance of :class:`GeoCoord` will have attributes:
@@ -237,7 +238,7 @@ def string_to_h3(h3_address):
 
 
 def h3_to_string(h3_int):
-    return hex(h3_int)[2:]
+    return format(h3_int, 'x')
 
 
 def h3_is_valid(h3_address):

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -233,10 +233,10 @@ libh3.h3Distance.restype = c_int
 libh3.h3Distance.argtypes = [H3Index, H3Index]
 
 libh3.h3LineSize.restype = c_int
-libh3.h3LineSize.argtypes = [c_long, c_long]
+libh3.h3LineSize.argtypes = [H3Index, H3Index]
 
 libh3.h3Line.restype = c_int
-libh3.h3Line.argtypes = [c_long, c_long]
+libh3.h3Line.argtypes = [H3Index, H3Index]
 
 
 def string_to_h3(h3_address):
@@ -777,7 +777,7 @@ def h3_line(h3_address_origin, h3_address_h3):
     array_len = h3_line_size(h3_address_origin, h3_address_h3)
     if array_len < 0:
         raise ValueError('Failed to compute a line, see docs for possible reasons')
-    IndexArray = c_long * array_len
+    IndexArray = H3Index * array_len
     index_array = IndexArray()
     ret_val = libh3.h3Line(string_to_h3(h3_address_origin),
                            string_to_h3(h3_address_h3),

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -37,12 +37,12 @@ from ctypes import (
 _dirname = os.path.dirname(__file__)
 libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
               if platform.system() == 'Darwin' else (
-              '{}\\{}'.format(_dirname, 'out\\h3.lib') if platform.system() == 'Windows' else
+              '{}\\{}'.format(_dirname, 'out\\h3.dll') if platform.system() == 'Windows' else
               '{}/{}'.format(_dirname, 'out/libh3.so.1')))
 
 # Load the Windows version of libc for H3 to use (calloc, free, etc)
-if platform.system() == 'Windows':
-    cdll.LoadLibrary(ctypes_util.find_msvcrt())
+# if platform.system() == 'Windows':
+#     cdll.LoadLibrary(ctypes_util.find_msvcrt())
 
 libh3 = cdll.LoadLibrary(libh3_path)
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -42,7 +42,7 @@ libh3_path = ('{}/{}'.format(_dirname, 'out/libh3.1.dylib')
 
 # Load the Windows version of libc for H3 to use (calloc, free, etc)
 if platform.system() == 'Windows':
-    cdll(ctypes_util.find_msvcrt())
+    cdll.LoadLibrary(ctypes_util.find_msvcrt())
 
 libh3 = cdll.LoadLibrary(libh3_path)
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -31,7 +31,6 @@ from ctypes import (
     byref,
     Structure,
     POINTER,
-#    util as ctypes_util,
 )
 
 _dirname = os.path.dirname(__file__)

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -31,7 +31,7 @@ from ctypes import (
     byref,
     Structure,
     POINTER,
-    util as ctypes_util,
+#    util as ctypes_util,
 )
 
 _dirname = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ from binding_version import binding_version
 
 
 def install_h3(h3_version):
-    subprocess.check_call('bash ./.install.sh {}'.format(h3_version), shell=True)
+    # Recommended by Python docs for determining the 64-bit-ness of the current
+    # interpreter. Needed for invoking CMake correctly on Windows.
+    is_64bits = sys.maxsize > 2**32
+    subprocess.check_call('bash ./.install.sh {} {}'.format(h3_version, is_64bits), shell=True)
 
 
 class CustomBuildExtCommand(build_ext):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ setup(
     },
     package_data={
         'h-py':
-        ['out/*.dylib' if platform.system() == 'Darwin' else 'out/*.so.*']
+        ['out/*.dylib' if platform.system() == 'Darwin' else (
+            'out/*.dll' if platform.system() == 'Windows' else
+            'out/*.so.*')]
     },
     license='Apache License 2.0',
     distclass=BinaryDistribution)

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -455,9 +455,13 @@ class TestH3Core(unittest.TestCase):
             multi_polygon[0], multi_polygon[-1],
             'first coord should be the same as last coord according to geojson format'
         )
-        self.assertEqual(
-            multi_polygon[0][0][0], [-122.42778275313199, 37.77598951883773],
-            'the coord should be (lng, lat) according to geojson format'
+        self.assertAlmostEqual(
+            multi_polygon[0][0][0][0], -122.42778275313199, None,
+            'the coord should be (lng, lat) according to geojson format (1)'
+        )
+        self.assertAlmostEqual(
+            multi_polygon[0][0][0][1], 37.77598951883773, None,
+            'the coord should be (lng, lat) according to geojson format (2)'
         )
         # Discard last coord for testing below, since last coord is the same as the first one
         multi_polygon[0][0].pop()

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -18,6 +18,7 @@ import pytest
 import unittest
 
 from h3 import h3
+from numbers import Number
 
 
 class TestH3Core(unittest.TestCase):
@@ -874,7 +875,7 @@ class TestH3Core(unittest.TestCase):
 
     def test_num_hexagons(self):
         for i in range(0, 15):
-            self.assertTrue(isinstance(h3.num_hexagons(i), int))
+            self.assertTrue(isinstance(h3.num_hexagons(i), Number))
 
     def test_h3_get_base_cell(self):
         self.assertTrue(isinstance(h3.h3_get_base_cell('8928308280fffff'), int))


### PR DESCRIPTION
Addresses #32

This PR is based on @dfellis' branch working on Windows support and includes his commits too.

Adds ability to build on Windows, which was tested on Appveyor. We'll need to enable Appveyor on this repository, too.

There are a number of assumptions built into the build script which probably need to be documented. Specifically, if you want a 64-bit build, you must specify the environment variable `PYTHON_ARCH=64`. I'm not sure what the more idiomatic way of doing this is, perhaps we should check the processor architecture env variable?

Several issues were fixed to get it working on Windows:
* The type of `H3Index` should be `c_ulonglong`. On Windows, `long` and `c_long` are always 32 bits. I assigned this its own name in h3.py to be more explicit about what we mean.
* Fixed a test that was comparing floats for equality.
* Python 2.7: Fixed a test that checked for a number being an `int`. I presume it was a `long` instead.
* Python 2.7: Looks to me like formatting of indexes as strings was not working in Python 2.7 because it added a 'L' suffix.