### PR TITLE
remove null values in k_ring_distances and hex_range_distance

### DIFF
--- a/h3/h3.py
+++ b/h3/h3.py
@@ -601,9 +601,8 @@ def hex_range_distances(h3_address, ring_size):
     for i in range(0, ring_size + 1):
         out.append(set([]))
     for i in range(0, array_len):
-        if krings[i] != 0:
-            ring_index = distances[i]
-            out[ring_index].add(h3_to_string(krings[i]))
+        ring_index = distances[i]
+        out[ring_index].add(h3_to_string(krings[i]))
     return out
 
 

--- a/h3/h3.py
+++ b/h3/h3.py
@@ -352,8 +352,9 @@ def k_ring_distances(h3_address, ring_size):
     for i in range(0, ring_size + 1):
         out.append(set([]))
     for i in range(0, array_len):
-        ring_index = distances[i]
-        out[ring_index].add(h3_to_string(krings[i]))
+        if krings[i] != 0:
+            ring_index = distances[i]
+            out[ring_index].add(h3_to_string(krings[i]))
     return out
 
 
@@ -600,8 +601,9 @@ def hex_range_distances(h3_address, ring_size):
     for i in range(0, ring_size + 1):
         out.append(set([]))
     for i in range(0, array_len):
-        ring_index = distances[i]
-        out[ring_index].add(h3_to_string(krings[i]))
+        if krings[i] != 0:
+            ring_index = distances[i]
+            out[ring_index].add(h3_to_string(krings[i]))
     return out
 
 

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -204,6 +204,12 @@ class TestH3Core(unittest.TestCase):
         self.assertTrue('89283082873ffff' in hexagons[1])
         self.assertTrue('8928308283bffff' in hexagons[1])
 
+        hexagons = h3.k_ring_distances('870800003ffffff', 2)
+        self.assertEqual(3, len(hexagons))
+        self.assertEqual(1, len(hexagons[0]))
+        self.assertEqual(6, len(hexagons[1]))
+        self.assertEqual(11, len(hexagons[2]))
+
     def test_polyfill(self):
         hexagons = h3.polyfill(
             {


### PR DESCRIPTION
#42 
hexagon_c_array_to_set has removed zero values in the output of k_ring and hex_range method.
k_ring_distances and hex_range_distances should return a similar result with 0 value excluded. 

Tested by running locally
```
>>> h3.k_ring_distances('870800003ffffff', 2)
[set(['870800003ffffff']), set(['870800002ffffff', '870800000ffffff', '87080001cffffff', '87080001dffffff', '870800005ffffff', '87080002affffff']), set(['870800018ffffff', '87080002bffffff', '870800019ffffff', '87080002effffff', '870800015ffffff', '870800011ffffff', '870800028ffffff', '87080001effffff', '870800006ffffff', '870800004ffffff', '870800023ffffff'])]
>>> h3.k_ring('870800003ffffff', 2)
set(['870800018ffffff', '87080002bffffff', '870800019ffffff', '870800003ffffff', '87080002effffff', '870800015ffffff', '870800011ffffff', '870800000ffffff', '87080001cffffff', '870800002ffffff', '870800028ffffff', '87080001dffffff', '87080001effffff', '870800005ffffff', '870800006ffffff', '87080002affffff', '870800004ffffff', '870800023ffffff'])
```
