### PR TITLE
Basic code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ install:
   - CFLAGS='-fPIC' python setup.py install
 script:
   - flake8 src/h3 setup.py
-  - pytest tests/*
+  - pytest tests/* --cov=h3
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install -r requirements-dev.txt
   - CFLAGS='-fPIC' python setup.py install
 script:
-  - flake8 src/h3 setup.py
+  - flake8 src/h3 setup.py tests
   - pytest tests/* --cov=h3
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install -r requirements-dev.txt
   - CFLAGS='-fPIC' python setup.py install
 script:
-  - flake8 src/h3 setup.py tests
+  - flake8 src/h3 setup.py
   - pytest tests/* --cov=h3
 after_success:
   - codecov

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ purge:
 	-@rm -rf .pytest_cache tests/__pycache__ __pycache__ _skbuild dist
 
 test:
-	env/bin/pytest tests/*
+	env/bin/pytest tests/* --cov=h3
 
 lint:
 	flake8 src/h3 setup.py

--- a/makefile
+++ b/makefile
@@ -23,10 +23,10 @@ purge:
 	find . -type d -name '*.egg-info' | xargs rm -r
 	find . -type f -name '*.pyc' | xargs rm -r
 	find . -type d -name '*.ipynb_checkpoints' | xargs rm -r
-	-@rm -rf .pytest_cache tests/__pycache__ __pycache__ _skbuild dist
+	-@rm -rf .pytest_cache tests/__pycache__ __pycache__ _skbuild dist .coverage
 
 test:
 	env/bin/pytest tests/* --cov=h3
 
 lint:
-	flake8 src/h3 setup.py
+	flake8 src/h3 setup.py tests

--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,4 @@ Try from within `ipython`:
 ```
 
 # to run tests
-- `make test`
+- `make test

--- a/readme.md
+++ b/readme.md
@@ -17,4 +17,4 @@ Try from within `ipython`:
 ```
 
 # to run tests
-- `make test
+- `make test`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,6 @@ scikit-build
 
 # Testing
 pytest
+pytest-cov
+codecov
 flake8

--- a/src/h3/h3core.pyx
+++ b/src/h3/h3core.pyx
@@ -1,8 +1,13 @@
 cimport h3lib
-from .h3utils cimport check_addr, check_edge, check_res, create_mv, create_ptr
+from h3lib cimport bool, int64_t, H3int
 
-from cpython cimport bool
-from libc.stdint cimport int64_t
+from .h3utils cimport (
+    check_addr,
+    check_edge,
+    check_res,
+    create_mv,
+    create_ptr
+)
 
 from h3.h3utils import H3ValueError
 from h3.geo import (
@@ -14,31 +19,37 @@ from h3.geo import (
 )
 
 cpdef basestring _c_version():
-    c = (h3lib.H3_VERSION_MAJOR, h3lib.H3_VERSION_MINOR, h3lib.H3_VERSION_PATCH)
-    c = '{}.{}.{}'.format(*c)
+    v = (
+        h3lib.H3_VERSION_MAJOR,
+        h3lib.H3_VERSION_MINOR,
+        h3lib.H3_VERSION_PATCH,
+    )
 
-    return c
+    return '{}.{}.{}'.format(*v)
+
+# todo: add notes about Cython exception handling
 
 
 # bool is a python type, so we don't need the except clause
-cpdef bool is_cell(h3lib.H3int h):
+cpdef bool is_cell(H3int h):
     """Validates an H3 cell (hexagon or pentagon)
+
     Returns
     -------
     boolean
     """
     return h3lib.h3IsValid(h) == 1
 
-cpdef bool is_pentagon(h3lib.H3int h):
+cpdef bool is_pentagon(H3int h):
     return h3lib.h3IsPentagon(h) == 1
 
-cpdef int get_base_cell(h3lib.H3int h) except -1:
+cpdef int get_base_cell(H3int h) except -1:
     check_addr(h)
 
     return h3lib.h3GetBaseCell(h)
 
 
-cpdef int resolution(h3lib.H3int h) except -1:
+cpdef int resolution(H3int h) except -1:
     """Returns the resolution of an H3 Index
     0--15
     """
@@ -47,7 +58,7 @@ cpdef int resolution(h3lib.H3int h) except -1:
     return h3lib.h3GetResolution(h)
 
 
-cpdef h3lib.H3int parent(h3lib.H3int h, res=None) except 1:
+cpdef H3int parent(H3int h, res=None) except 1:
     check_addr(h)
 
     if res is None:
@@ -58,7 +69,7 @@ cpdef h3lib.H3int parent(h3lib.H3int h, res=None) except 1:
     return h3lib.h3ToParent(h, res)
 
 
-cpdef int distance(h3lib.H3int h1, h3lib.H3int h2) except -1:
+cpdef int distance(H3int h1, H3int h2) except -1:
     """ compute the hex-distance between two hexagons
     """
     check_addr(h1)
@@ -68,7 +79,7 @@ cpdef int distance(h3lib.H3int h1, h3lib.H3int h2) except -1:
 
     return d
 
-cpdef h3lib.H3int[:] disk(h3lib.H3int h, int k):
+cpdef H3int[:] disk(H3int h, int k):
     """ Return cells at grid distance `<= k` from `h`.
     """
     check_addr(h)
@@ -83,7 +94,7 @@ cpdef h3lib.H3int[:] disk(h3lib.H3int h, int k):
 
     return mv
 
-cpdef h3lib.H3int[:] ring(h3lib.H3int h, int k):
+cpdef H3int[:] ring(H3int h, int k):
     """ Return cells at grid distance `== k` from `h`.
     Collection is "hollow" for k >= 1.
     """
@@ -113,7 +124,7 @@ cpdef h3lib.H3int[:] ring(h3lib.H3int h, int k):
 
 
 
-cpdef h3lib.H3int[:] children(h3lib.H3int h, res=None):
+cpdef H3int[:] children(H3int h, res=None):
     check_addr(h)
 
     if res is None:
@@ -131,7 +142,7 @@ cpdef h3lib.H3int[:] children(h3lib.H3int h, res=None):
 
 
 
-cpdef h3lib.H3int[:] compact(const h3lib.H3int[:] hu):
+cpdef H3int[:] compact(const H3int[:] hu):
     for h in hu:
         check_addr(h)
 
@@ -146,7 +157,7 @@ cpdef h3lib.H3int[:] compact(const h3lib.H3int[:] hu):
 
 # todo: https://stackoverflow.com/questions/50684977/cython-exception-type-for-a-function-returning-a-typed-memoryview
 # apparently, memoryviews are python objects, so we don't need to do the except clause
-cpdef h3lib.H3int[:] uncompact(const h3lib.H3int[:] hc, int res):
+cpdef H3int[:] uncompact(const H3int[:] hc, int res):
     for h in hc:
         check_addr(h)
 
@@ -201,14 +212,14 @@ cpdef double mean_edge_length(int resolution, unit='km') except -1:
 
 
 
-cpdef bool are_neighbors(h3lib.H3int h1, h3lib.H3int h2):
+cpdef bool are_neighbors(H3int h1, H3int h2):
     check_addr(h1)
     check_addr(h2)
 
     return h3lib.h3IndexesAreNeighbors(h1, h2) == 1
 
 
-cpdef h3lib.H3int edge(h3lib.H3int origin, h3lib.H3int destination) except 1:
+cpdef H3int edge(H3int origin, H3int destination) except 1:
     check_addr(origin)
     check_addr(destination)
 
@@ -218,27 +229,27 @@ cpdef h3lib.H3int edge(h3lib.H3int origin, h3lib.H3int destination) except 1:
     return h3lib.getH3UnidirectionalEdge(origin, destination)
 
 
-cpdef bool is_edge(h3lib.H3int e):
+cpdef bool is_edge(H3int e):
     check_edge(e)
 
     return h3lib.h3UnidirectionalEdgeIsValid(e) == 1
 
-cpdef h3lib.H3int edge_origin(h3lib.H3int e) except 1:
+cpdef H3int edge_origin(H3int e) except 1:
     check_edge(e)
 
     return h3lib.getOriginH3IndexFromUnidirectionalEdge(e)
 
-cpdef h3lib.H3int edge_destination(h3lib.H3int e) except 1:
+cpdef H3int edge_destination(H3int e) except 1:
     check_edge(e)
 
     return h3lib.getDestinationH3IndexFromUnidirectionalEdge(e)
 
-cpdef (h3lib.H3int, h3lib.H3int) edge_cells(h3lib.H3int e) except *:
+cpdef (H3int, H3int) edge_cells(H3int e) except *:
     check_edge(e)
 
     return edge_origin(e), edge_destination(e)
 
-cpdef h3lib.H3int[:] edges_from_cell(h3lib.H3int origin):
+cpdef H3int[:] edges_from_cell(H3int origin):
     """ Returns the 6 (or 5 for pentagons) directed edges
     for the given origin cell
     """
@@ -250,7 +261,7 @@ cpdef h3lib.H3int[:] edges_from_cell(h3lib.H3int origin):
 
     return mv
 
-cpdef h3lib.H3int[:] line(h3lib.H3int start, h3lib.H3int end):
+cpdef H3int[:] line(H3int start, H3int end):
     check_addr(start)
     check_addr(end)
 

--- a/src/h3/h3lib.pxd
+++ b/src/h3/h3lib.pxd
@@ -1,4 +1,6 @@
 from libc cimport stdint
+from cpython cimport bool
+from libc.stdint cimport int64_t
 
 ctypedef stdint.uint64_t H3int
 ctypedef basestring H3str
@@ -130,7 +132,7 @@ cdef extern from "h3api.h":
     void getH3UnidirectionalEdgesFromHexagon(H3Index origin, H3Index *edges)
 
     void getH3UnidirectionalEdgeBoundary(H3Index edge, GeoBoundary *gb)
-    
+
     int h3LineSize(H3int start, H3int end)
 
     int h3Line(H3int start, H3int end, H3int *out)

--- a/src/h3/h3utils.pyx
+++ b/src/h3/h3utils.pyx
@@ -18,29 +18,26 @@ cpdef H3str int2hex(H3int x):
 class H3ValueError(ValueError):
     pass
 
-class InvalidH3Address(H3ValueError):
+class H3CellError(H3ValueError):
     pass
-    # todo: rename to H3InvalidCellError?
 
-class InvalidH3Edge(H3ValueError):
+class H3EdgeError(H3ValueError):
     pass
-    # todo: rename to H3InvalidEdgeError?
 
-class InvalidH3Resolution(H3ValueError):
+class H3ResolutionError(H3ValueError):
     pass
-    # todo: rename to H3ResolutionError?
 
 cdef check_addr(H3int h):
     if h3IsValid(h) == 0:
-        raise InvalidH3Address(h)
+        raise H3CellError(h)
 
 cdef check_edge(H3int e):
     if h3UnidirectionalEdgeIsValid(e) == 0:
-        raise InvalidH3Edge(e)
+        raise H3EdgeError(e)
 
 cdef check_res(int res):
-    if res < 0 or res > 15:
-        raise InvalidH3Resolution(res)
+    if (res < 0) or (res > 15):
+        raise H3ResolutionError(res)
 
 
 
@@ -92,9 +89,12 @@ cpdef H3int[:] from_iter(hexes):
 cdef size_t move_nonzeros(H3int* a, size_t n):
     """ Move nonzero elements to front of array `a` of length `n`.
     Return the number of nonzero elements.
+
     | a | b | 0 | c | d | ... |
             ^           ^
             i           j
+
+
     | a | b | d | c | d | ... |
             ^       ^
             i       j

--- a/tests/test.py
+++ b/tests/test.py
@@ -84,7 +84,6 @@ def test7():
 def test8():
     assert h3.h3_is_valid('89283082803ffff')
     assert not h3.h3_is_valid('abc')
-    assert not h3.h3_is_valid('zzz')
 
     # looks like it might be valid, but it isn't!
     h_bad = '8a28308280fffff'

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,10 @@
 import h3
-from h3.h3utils import InvalidH3Address, InvalidH3Resolution, InvalidH3Edge, H3ValueError
+from h3.h3utils import (
+    H3ValueError,
+    H3CellError,
+    H3ResolutionError,
+    H3EdgeError
+)
 import pytest
 
 
@@ -90,7 +95,7 @@ def test8():
     assert not h3.h3_is_valid(h_bad)
 
     # other methods should validate and raise exception if bad input
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_get_resolution(h_bad)
 
 def test9():
@@ -315,38 +320,38 @@ def test_edge_boundary():
 def test_validation():
     h = '8a28308280fffff' # invalid hex
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_get_base_cell(h)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_get_resolution(h)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_to_parent(h, 9)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_distance(h, h)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.k_ring(h, 1)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.hex_ring(h, 1)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_to_children(h, 11)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.compact({h})
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.uncompact({h}, 10)
 
 
 def test_validation2():
     h = '8928308280fffff'
 
-    with pytest.raises(InvalidH3Resolution):
+    with pytest.raises(H3ResolutionError):
         h3.h3_to_children(h, 17)
 
     assert not h3.h3_indexes_are_neighbors(h,h)
@@ -357,16 +362,16 @@ def test_validation2():
 def test_validation_geo():
     h = '8a28308280fffff' # invalid hex
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_to_geo(h)
 
-    with pytest.raises(InvalidH3Resolution):
+    with pytest.raises(H3ResolutionError):
         h3.geo_to_h3(0,0,17)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_to_geo_boundary(h)
 
-    with pytest.raises(InvalidH3Address):
+    with pytest.raises(H3CellError):
         h3.h3_indexes_are_neighbors(h,h)
 
 def test_edges():
@@ -383,13 +388,13 @@ def test_edges():
     e_bad = '14928308280ffff1'
     assert not h3.h3_unidirectional_edge_is_valid(e_bad)
 
-    with pytest.raises(InvalidH3Edge):
+    with pytest.raises(H3EdgeError):
         h3.get_origin_h3_index_from_unidirectional_edge(e_bad)
 
-    with pytest.raises(InvalidH3Edge):
+    with pytest.raises(H3EdgeError):
         h3.get_destination_h3_index_from_unidirectional_edge(e_bad)
 
-    with pytest.raises(InvalidH3Edge):
+    with pytest.raises(H3EdgeError):
         h3.get_h3_indexes_from_unidirectional_edge(e_bad)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -84,6 +84,7 @@ def test7():
 def test8():
     assert h3.h3_is_valid('89283082803ffff')
     assert not h3.h3_is_valid('abc')
+    assert not h3.h3_is_valid('zzz')
 
     # looks like it might be valid, but it isn't!
     h_bad = '8a28308280fffff'


### PR DESCRIPTION
Currently only covers `.py` files. Ideally, we'd get this to also compute coverage on Cython files.