### PR TITLE
Remove version checks in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,6 @@
 cmake_minimum_required(VERSION 3.7.2)
 
-set(version_regex "([0-9.]+)")
-file(STRINGS "src/h3lib/VERSION" h3_version
-     REGEX "^${version_regex}$")
-message(STATUS "h3 version: ${h3_version}")
-
-set(py_version_regex "^version = '${version_regex}'$")
-file(STRINGS "src/h3/_version.py" version_line
-     REGEX "${py_version_regex}")
-string(REGEX MATCH "${py_version_regex}" _ "${version_line}")
-set(version "${CMAKE_MATCH_1}")
-message(STATUS "h3-py version: ${version}")
-
-project(h3 VERSION "${version}")
+project(h3)
 
 # Build the core library as static
 set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
Since we're using `git submodule`, we don't need the version check code in `CMakeLists.txt`.

One potential question, however, is if we should be using `git submodule`, or an alternative like `git subtree`.