### PR TITLE
Changes to build wheel for Windows 10 64bit

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -37,7 +37,9 @@ if [ "Windows_NT" != "$OS" ]; then
 else
   # Assumed to be Windows, default to x86
   if [[ "True" == "$IS_64BITS" ]]; then
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 16 2019"
+    # to build on win 10 with VS 16 use this command:
+    # cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 16 2019"
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 Win64"
   else
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON
   fi

--- a/.install.sh
+++ b/.install.sh
@@ -38,8 +38,7 @@ else
   # Assumed to be Windows, default to x86
   if [[ "True" == "$IS_64BITS" ]]; then
     # to build on win 10 with VS 16 use this command:
-    # cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 16 2019"
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 Win64"
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -A x64
   else
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON
   fi

--- a/.install.sh
+++ b/.install.sh
@@ -37,7 +37,7 @@ if [ "Windows_NT" != "$OS" ]; then
 else
   # Assumed to be Windows, default to x86
   if [[ "True" == "$IS_64BITS" ]]; then
-    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 14 Win64"
+    cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON -G "Visual Studio 16 2019"
   else
     cmake . -DENABLE_FORMAT=OFF -DBUILD_SHARED_LIBS=ON
   fi

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         'build_ext': CustomBuildExtCommand,
     },
     package_data={
-        'h-py':
+        'h3':
         ['out/*.dylib' if platform.system() == 'Darwin' else (
             'out/*.dll' if platform.system() == 'Windows' else
             'out/*.so.*')]


### PR DESCRIPTION
To be able to build ``h3`` wheel I installed on a new Windows 10 64 bit machine:
 * git for windows
 * git bash for windows
 * python 3.7 for windows
 * cmake for windows
 * Microsoft Visual Studio Community Edition (configuration export attached)

Made the 2 changes in the PR.

Run the command: ``python setup.py bdist_wheel``

I hope it will help you.

[dot_vsconfig.zip](https://github.com/uber/h3-py/files/4085229/dot_vsconfig.zip)

