### PR TITLE
Windows wheels

### DIFF
--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -34,8 +34,8 @@ jobs:
           pip install scikit-build
           python setup.py sdist --dist-dir=wheelhouse
 
-      # - name: Upload artifacts to github
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: wheels
-      #     path: ./wheelhouse
+      - name: Upload artifacts to github
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
-          pip install --upgrade cibuildwheel pip setuptools wheel
+          pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Build sdist

--- a/.github/workflows/wheels-linux.yml
+++ b/.github/workflows/wheels-linux.yml
@@ -34,8 +34,8 @@ jobs:
           pip install scikit-build
           python setup.py sdist --dist-dir=wheelhouse
 
-      - name: Upload artifacts to github
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse
+      # - name: Upload artifacts to github
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: wheels
+      #     path: ./wheelhouse

--- a/.github/workflows/wheels-mac.yml
+++ b/.github/workflows/wheels-mac.yml
@@ -26,7 +26,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
-          pip install --upgrade cibuildwheel pip setuptools wheel
+          pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
       # - name: Upload artifacts to github

--- a/.github/workflows/wheels-mac.yml
+++ b/.github/workflows/wheels-mac.yml
@@ -29,8 +29,8 @@ jobs:
           pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
-      # - name: Upload artifacts to github
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: wheels
-      #     path: ./wheelhouse
+      - name: Upload artifacts to github
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse

--- a/.github/workflows/wheels-mac.yml
+++ b/.github/workflows/wheels-mac.yml
@@ -29,8 +29,8 @@ jobs:
           pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload artifacts to github
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse
+      # - name: Upload artifacts to github
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: wheels
+      #     path: ./wheelhouse

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27*
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: ilammy/msvc-dev-cmd@v1.2.0
-
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  CC: cl.exe
-  CXX: cl.exe
-
 jobs:
   tests:
     name: Python Wheels Windows

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27*
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_SKIP: pp* cp27* *-win32
+          CIBW_SKIP: pp* *-win32
           CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake ninja
+          CIBW_BEFORE_BUILD: pip install scikit-build cython
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -36,6 +36,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
+          pip install --upgrade scikit-build
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload artifacts to github

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           python-version: 3.8
 
+      - uses: ilammy/msvc-dev-cmd@v1.2.0
+
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
-          CIBW_BEFORE_BUILD: pip install scikit-build cython
+          CIBW_BEFORE_BUILD: pip install scikit-build cython cmake
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install --upgrade cibuildwheel setuptools wheel scikit-build
+          pip install --upgrade cibuildwheel
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27*
+          CIBW_BEFORE_BUILD: pip install scikit-build
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
-          pip install --upgrade scikit-build
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload artifacts to github

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -24,12 +24,6 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: ilammy/msvc-dev-cmd@v1.2.0
-
-      - name: Install packages
-        run: |
-          pip install --upgrade cibuildwheel
-
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
@@ -37,6 +31,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
+          pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload artifacts to github

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake ninja
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_SKIP: pp* cp27*
+          CIBW_SKIP: pp* cp27* *-win32
           CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27*
-          CIBW_BEFORE_BUILD: pip install scikit-build
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CC: cl.exe
+  CXX: cl.exe
+
 jobs:
   tests:
     name: Python Wheels Windows

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32
-          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
+          CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_SKIP: pp*
+          CIBW_SKIP: pp* cp27*
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -1,0 +1,42 @@
+name: wheels-windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CC: cl.exe
+  CXX: cl.exe
+
+jobs:
+  tests:
+    name: Python Wheels Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2.1.1
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - uses: ilammy/msvc-dev-cmd@v1.2.0
+
+      - name: Build wheels
+        env:
+          CIBW_SKIP: pp*
+          CIBW_TEST_REQUIRES: pytest numpy
+          CIBW_TEST_COMMAND: pytest {project}/tests
+        run: |
+          pip install --upgrade cibuildwheel pip setuptools wheel
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Upload artifacts to github
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -36,8 +36,8 @@ jobs:
           pip install --upgrade cibuildwheel
           python -m cibuildwheel --output-dir wheelhouse
 
-      - name: Upload artifacts to github
-        uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse
+      # - name: Upload artifacts to github
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: wheels
+      #     path: ./wheelhouse

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -26,13 +26,16 @@ jobs:
 
       - uses: ilammy/msvc-dev-cmd@v1.2.0
 
+      - name: Install packages
+        run: |
+          pip install --upgrade cibuildwheel pip setuptools wheel scikit-build
+
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27*
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
         run: |
-          pip install --upgrade cibuildwheel pip setuptools wheel
           python -m cibuildwheel --output-dir wheelhouse
 
       - name: Upload artifacts to github

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install packages
         run: |
-          pip install --upgrade cibuildwheel pip setuptools wheel scikit-build
+          pip install --upgrade cibuildwheel setuptools wheel scikit-build
 
       - name: Build wheels
         env:

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: 3.8
 
+      - uses: ilammy/msvc-dev-cmd@v1.2.0
+
       - name: Build wheels
         env:
           CIBW_SKIP: pp* cp27* *-win32

--- a/.github/workflows/wheels-windows.yml
+++ b/.github/workflows/wheels-windows.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build wheels
         env:
-          CIBW_SKIP: pp* *-win32
+          CIBW_SKIP: pp* cp27* *-win32
           CIBW_BEFORE_BUILD: pip install scikit-build cmake cython ninja wheel setuptools
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,4 @@ requires = [
     'scikit-build',
     'cython',
     'cmake',
-    'ninja',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
-    'setuptools',
-    'wheel',
     'scikit-build',
+    'cython',
     'cmake',
     'ninja',
-    'cython',
 ]


### PR DESCRIPTION
Building Windows wheels for CPython `3.5`, `3.6`, `3.7`, `3.8`.

TODO: The windows build requires `CIBW_BEFORE_BUILD: pip install scikit-build cython cmake` to specify the build dependencies. This is unnecessary on Linux/mac, as it gets picked up automatically from the `pyproject.toml` file. Not clear why this doesn't work on Windows. Follow this issue: https://github.com/joerick/cibuildwheel/issues/350