### PR TITLE
Fix error checking on `hex2int`

### DIFF
--- a/src/h3/_cy/util.pxd
+++ b/src/h3/_cy/util.pxd
@@ -1,6 +1,6 @@
 from .h3lib cimport H3int, H3str
 
-cpdef H3int hex2int(H3str h) except 0
+cpdef H3int hex2int(H3str h) except? 0
 cpdef H3str int2hex(H3int x)
 
 cdef H3int* create_ptr(size_t n) except? NULL

--- a/src/h3/_cy/util.pyx
+++ b/src/h3/_cy/util.pyx
@@ -15,7 +15,7 @@ cpdef basestring c_version():
     return '{}.{}.{}'.format(*v)
 
 
-cpdef H3int hex2int(H3str h) except 0:
+cpdef H3int hex2int(H3str h) except? 0:
     return int(h, 16)
 
 

--- a/tests/test_cells_and_edges.py
+++ b/tests/test_cells_and_edges.py
@@ -475,3 +475,13 @@ def test_get_pentagons():
 
     for i in range(16):
         assert len(h3.get_pentagon_indexes(i)) == 12
+
+
+def test_uncompact_cell_input():
+    # `uncompact` takes in a collection of cells, not a single cell.
+    # Since a python string is seen as a Iterable collection,
+    # inputting a single cell string can raise weird errors.
+
+    # Ensure we get a reasonably helpful answer
+    with pytest.raises(H3CellError):
+        h3.uncompact('8001fffffffffff', 1)


### PR DESCRIPTION
Change from

```python
cpdef H3int hex2int(H3str h) except 0
```
to
```python
cpdef H3int hex2int(H3str h) except? 0
```

The previous version considered **any** return of `0` an error, which led to confusing error messages for the user. This function simply converts; check for a valid cell happens after conversion.

Changing `except 0` to `except? 0` makes it so that Python only **checks** if there is an error when `0` is returned. [We need *some* C-compatible sentinel value to flag actual/potential errors for pure C/Cython functions](https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#error-return-values).

Old error message:
<img width="873" alt="Screen Shot 2020-05-30 at 11 46 54 AM" src="https://user-images.githubusercontent.com/984039/83337092-75d13000-a26d-11ea-813e-a7f198357ea2.png">

New error message:
<img width="882" alt="Screen Shot 2020-05-30 at 11 44 51 AM" src="https://user-images.githubusercontent.com/984039/83337093-78338a00-a26d-11ea-81ff-7bde53903f64.png">

This PR also adds a test to verify that we get a helpful error message in this example.
