### PR TITLE
Build Python 2.7 wheels on Linux

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
     steps:
 
@@ -63,7 +63,7 @@ jobs:
       - name: Build Linux
         if: startsWith(matrix.os, 'ubuntu')
         env:
-          CIBW_SKIP: pp* cp27* *-manylinux_i686
+          CIBW_SKIP: pp* *-manylinux_i686
         run: |
           python -m cibuildwheel --output-dir wheelhouse
           python setup.py sdist --dist-dir=wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
+
+## [3.6.2] - 2020-06-02
+
 - Improve error reporting on `hex2int` (https://github.com/uber/h3-py/pull/127)
+- Build Linux wheels for Python 2.7
 
 ## [3.6.1] - 2020-05-29
 

--- a/src/h3/_version.py
+++ b/src/h3/_version.py
@@ -1,4 +1,4 @@
-__version__ = '3.6.1'
+__version__ = '3.6.2'
 __description__ = 'Hierarchical hexagonal geospatial indexing system'
 __url__ = 'https://github.com/uber/h3-py'
 __license__ = "Apache 2.0 License"


### PR DESCRIPTION
I don't remember why I was avoiding Python 2.7 wheels on Linux before, but they seem to be working fine now. 