### PR TITLE
first draft of v4 names

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    */h3/unstable/*

--- a/src/h3/__init__.py
+++ b/src/h3/__init__.py
@@ -14,5 +14,3 @@ from ._cy import (
     H3EdgeError,
     H3DistanceError,
 )
-
-from . import unstable

--- a/src/h3/__init__.py
+++ b/src/h3/__init__.py
@@ -14,3 +14,5 @@ from ._cy import (
     H3EdgeError,
     H3DistanceError,
 )
+
+from . import unstable

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 
 import warnings
-s = 'Modules under `h3.unstable` are experimental, and may change at any time.'
-warnings.warn(s)
+warnings.warn(
+    'Modules under `h3.unstable` are experimental, and may change at any time.'
+)
 
 from . import v4

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,5 +1,4 @@
-"""
-This module contains code that is experimental and unstable.
-"""
+import warnings
+warnings.warn('Modules under `h3.unstable` are experimental, and may change at any time.')
 
 from . import v4

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 
-import warnings # pragma: no cover
-warnings.warn( # pragma: no cover
+import warnings
+warnings.warn(
     'Modules under `h3.unstable` are experimental, and may change at any time.'
-) # pragma: no cover
+)
 
-from . import v4  # pragma: no cover
+from . import v4

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,0 +1,5 @@
+"""
+This module contains code that is experimental and unstable.
+"""
+
+from . import v4

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,4 +1,7 @@
+# flake8: noqa
+
 import warnings
-warnings.warn('Modules under `h3.unstable` are experimental, and may change at any time.')
+s = 'Modules under `h3.unstable` are experimental, and may change at any time.'
+warnings.warn(s)
 
 from . import v4

--- a/src/h3/unstable/__init__.py
+++ b/src/h3/unstable/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 
-import warnings
-warnings.warn(
+import warnings # pragma: no cover
+warnings.warn( # pragma: no cover
     'Modules under `h3.unstable` are experimental, and may change at any time.'
-)
+) # pragma: no cover
 
-from . import v4
+from . import v4  # pragma: no cover

--- a/src/h3/unstable/v4.py
+++ b/src/h3/unstable/v4.py
@@ -7,7 +7,7 @@
 
 # what if we organized by module
 
-from ..api.basic_str import (   # pragma: no cover
+from ..api.basic_str import (
     compact as
         compact,
 

--- a/src/h3/unstable/v4.py
+++ b/src/h3/unstable/v4.py
@@ -1,57 +1,52 @@
 # flake8: noqa
 
-# todo: what are the pythonic names?
-
-# what if we put this in an object? what would it look like?
-# a temporary API wrapper
-
-# what if we organized by module
-
 from ..api.basic_str import (
+    # todo: implement is_valid_index
+
     compact as
-        compact,
+        compact_cells,
 
     edge_length as
-        hex_edge_length_avg,
+        get_hexagon_edge_length_avg,
 
     geo_to_h3 as
         point_to_cell,
 
     get_destination_h3_index_from_unidirectional_edge as
-        edge_destination,
+        get_directed_edge_destination,
 
     get_h3_indexes_from_unidirectional_edge as
-        directed_edge_cells,
+        directed_edge_to_cells,
 
     get_h3_unidirectional_edge as
         cells_to_directed_edge,
 
     get_h3_unidirectional_edge_boundary as
-        directed_edge_boundary, # what's a boundary?
+        directed_edge_to_boundary,
 
     get_h3_unidirectional_edges_from_hexagon as
         origin_to_directed_edges,
 
     get_origin_h3_index_from_unidirectional_edge as
-        edge_origin,
+        get_directed_edge_origin,
 
     get_pentagon_indexes as
-        pentagons,
+        get_pentagons,
 
     get_res0_indexes as
-        res0_cells,
+        get_res0_cells,
 
     h3_distance as
         grid_distance,
 
     h3_get_base_cell as
-        base_cell_number,
+        get_base_cell_number,
 
     h3_get_faces as
-        faces,
+        get_icosahedron_faces,
 
     h3_get_resolution as
-        resolution,
+        get_resolution,
 
     h3_indexes_are_neighbors as
         are_neighbor_cells,
@@ -61,7 +56,6 @@ from ..api.basic_str import (
 
     h3_is_res_class_III as
         is_res_class_III,
-    # h3_is_res_class_iii as _, # executive decision!
 
     h3_is_valid as
         is_valid_cell,
@@ -73,10 +67,10 @@ from ..api.basic_str import (
         cells_to_multipolygon,
 
     h3_to_center_child as
-        center_child,
+        cell_to_center_child,
 
     h3_to_children as
-        children,
+        cell_to_children,
 
     h3_to_geo as
         cell_to_point,
@@ -85,7 +79,7 @@ from ..api.basic_str import (
         cell_to_boundary,
 
     h3_to_parent as
-        parent,
+        cell_to_parent,
 
     h3_to_string as
         int_to_str,
@@ -94,7 +88,7 @@ from ..api.basic_str import (
         is_valid_directed_edge,
 
     hex_area as
-        hex_area_avg,
+        get_hexagon_area_avg,
 
     # hex_range as _,
     # hex_range_distances as _, # not sure we want this one; easy for user to implement
@@ -102,19 +96,15 @@ from ..api.basic_str import (
 
     hex_ring as
         grid_ring,
-    hex_ring as
-        ring, # used often enough that i think it deserves an alias
 
     k_ring as
         grid_disk,
-    k_ring as
-        disk, # used often enough that i think it deserves an alias
 
     k_ring_distances as
         grid_disk_distances,
 
     num_hexagons as
-        num_cells,
+        get_num_cells,
 
     polyfill as
         polygon_to_cells,
@@ -128,7 +118,7 @@ from ..api.basic_str import (
         str_to_int,
 
     uncompact as
-        uncompact,
+        uncompact_cells,
 
     versions as
         versions,

--- a/src/h3/unstable/v4.py
+++ b/src/h3/unstable/v4.py
@@ -1,0 +1,133 @@
+# todo: what are the pythonic names?
+
+# what if we put this in an object? what would it look like?
+# a temporary API wrapper
+
+# what if we organized by module
+
+from ..api.basic_str import (
+    compact as
+        compact,
+
+    edge_length as
+        hex_edge_length_avg,
+
+    geo_to_h3 as
+        point_to_cell,
+
+    get_destination_h3_index_from_unidirectional_edge as
+        edge_destination,
+
+    get_h3_indexes_from_unidirectional_edge as
+        directed_edge_cells,
+
+    get_h3_unidirectional_edge as
+        cells_to_directed_edge,
+
+    get_h3_unidirectional_edge_boundary as
+        directed_edge_boundary, # what's a boundary?
+
+    get_h3_unidirectional_edges_from_hexagon as
+        origin_to_directed_edges,
+
+    get_origin_h3_index_from_unidirectional_edge as
+        edge_origin,
+
+    get_pentagon_indexes as
+        pentagons,
+
+    get_res0_indexes as
+        res0_cells,
+
+    h3_distance as
+        grid_distance,
+
+    h3_get_base_cell as
+        base_cell_number,
+
+    h3_get_faces as
+        faces,
+
+    h3_get_resolution as
+        resolution,
+
+    h3_indexes_are_neighbors as
+        are_neighbor_cells,
+
+    h3_is_pentagon as
+        is_pentagon,
+
+    h3_is_res_class_III as
+        is_res_class_III,
+    # h3_is_res_class_iii as _, # executive decision!
+
+    h3_is_valid as
+        is_valid_cell,
+
+    h3_line as
+        grid_path_cells,
+
+    h3_set_to_multi_polygon as
+        cells_to_multipolygon,
+
+    h3_to_center_child as
+        center_child,
+
+    h3_to_children as
+        children,
+
+    h3_to_geo as
+        cell_to_point,
+
+    h3_to_geo_boundary as
+        cell_to_boundary,
+
+    h3_to_parent as
+        parent,
+
+    h3_to_string as
+        int_to_str,
+
+    h3_unidirectional_edge_is_valid as
+        is_valid_directed_edge,
+
+    hex_area as
+        hex_area_avg,
+
+    # hex_range as _,
+    # hex_range_distances as _, # not sure we want this one; easy for user to implement
+    # hex_ranges as _,
+
+    hex_ring as
+        grid_ring,
+    hex_ring as
+        ring, # used often enough that i think it deserves an alias
+
+    k_ring as
+        grid_disk,
+    k_ring as
+        disk, # used often enough that i think it deserves an alias
+
+    k_ring_distances as
+        grid_disk_distances,
+
+    num_hexagons as
+        num_cells,
+
+    polyfill as
+        polygon_to_cells,
+
+    polyfill_geojson as
+        geojson_to_cells, # still need to figure out the final polyfill interface
+
+    #polyfill_polygon as _,
+
+    string_to_h3 as
+        str_to_int,
+
+    uncompact as
+        uncompact,
+
+    versions as
+        versions,
+)

--- a/src/h3/unstable/v4.py
+++ b/src/h3/unstable/v4.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 # todo: what are the pythonic names?
 
 # what if we put this in an object? what would it look like?

--- a/src/h3/unstable/v4.py
+++ b/src/h3/unstable/v4.py
@@ -7,7 +7,7 @@
 
 # what if we organized by module
 
-from ..api.basic_str import (
+from ..api.basic_str import (   # pragma: no cover
     compact as
         compact,
 


### PR DESCRIPTION
Experimenting with the [planned v4.0.0 names in this H3 RFC](https://github.com/uber/h3/blob/master/dev-docs/RFCs/v4.0.0/names_for_concepts_types_functions.md).

Try it with something like:

```python
import h3.unstable.v4 as h3

h = h3.point_to_cell(0,0,0)
h3.cell_to_children(h)
h3.get_pentagons(0) < h3.get_res0_cells()
h3.grid_ring(h, k=5)
h3.grid_disk(h, k=3)
```