### PR TITLE
Windows Py3.5 fix for cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,7 @@ on:
   release:
 
 env:
+  CIBW_TEST_REQUIRES: pytest numpy
   CIBW_TEST_COMMAND: pytest {project}/tests
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -62,7 +62,6 @@ jobs:
           CIBW_SKIP: pp* *-manylinux_i686
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-          python setup.py sdist --dist-dir=wheelhouse
 
       - name: Make sdist
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,10 +8,6 @@ on:
   release:
 
 env:
-  # only needed for Py3.5 on Windows for some reason
-  # ideally, would be picked up from pyproject.toml
-  CIBW_BEFORE_BUILD: pip install scikit-build cython cmake
-
   CIBW_TEST_REQUIRES: pytest numpy
   CIBW_TEST_COMMAND: pytest {project}/tests
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,14 +31,14 @@ jobs:
         with:
           python-version: 3.8
 
-      - name: Install Deps
-        # only need scikit-build for the linux sdist step
-        run: pip install --upgrade cibuildwheel scikit-build twine
-
       - uses: ilammy/msvc-dev-cmd@v1.2.0
         if: startsWith(matrix.os, 'windows')
 
+
       ## Build across platforms
+
+      - name: Install cibuildwheel
+        run: pip install --upgrade cibuildwheel
 
       - name: Build Windows
         if: startsWith(matrix.os, 'windows')
@@ -64,10 +64,19 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
           python setup.py sdist --dist-dir=wheelhouse
 
+      - name: Make sdist
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          pip install --upgrade scikit-build
+          python setup.py sdist --dist-dir=wheelhouse
+
+
       ## Upload
 
       - name: Check with Twine
-        run: twine check wheelhouse/*
+        run: |
+          pip install --upgrade twine
+          twine check wheelhouse/*
 
       - name: Upload artifacts to GitHub
         if: github.event_name == 'release'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,6 @@ on:
   release:
 
 env:
-  CIBW_TEST_REQUIRES: pytest numpy
   CIBW_TEST_COMMAND: pytest {project}/tests
 
 jobs:


### PR DESCRIPTION
Fixed via changes available starting in `cibuildwheel==1.5.2`.

Closes https://github.com/uber/h3-py/issues/138

Related:
- https://github.com/joerick/cibuildwheel/pull/399
- https://github.com/joerick/cibuildwheel/pull/358
- https://github.com/joerick/cibuildwheel/pull/398