### PR TITLE
Add vectorized h3_to_parent and h3_get_resolution

### DIFF
--- a/src/h3/_cy/h3lib.pxd
+++ b/src/h3/_cy/h3lib.pxd
@@ -88,7 +88,7 @@ cdef extern from "h3api.h":
 
     stdint.int64_t numHexagons(int res)
 
-    int h3GetResolution(H3Index h)
+    int h3GetResolution(H3Index h) nogil
 
     int h3GetBaseCell(H3Index h)
 

--- a/src/h3/_cy/h3lib.pxd
+++ b/src/h3/_cy/h3lib.pxd
@@ -106,7 +106,7 @@ cdef extern from "h3api.h":
 
     int h3IsValid(H3Index h)
 
-    H3Index h3ToParent(H3Index h, int parentRes)
+    H3Index h3ToParent(H3Index h, int parentRes) nogil
 
     int maxH3ToChildrenSize(H3Index h, int childRes)
 

--- a/src/h3/_cy/unstable_vect.pyx
+++ b/src/h3/_cy/unstable_vect.pyx
@@ -64,7 +64,7 @@ cpdef void geo_to_h3_vect(
 @wraparound(False)
 cpdef void h3_to_parent_vect(
     const H3int[:] h,
-    unsigned char[:] res,
+    int[:] res,
     H3int[:] out
 ) nogil:
 
@@ -79,7 +79,7 @@ cpdef void h3_to_parent_vect(
 @wraparound(False)
 cpdef void h3_get_resolution_vect(
     const H3int[:] h,
-    unsigned char[:] out,
+    int[:] out,
 ) nogil:
 
     cdef Py_ssize_t i

--- a/src/h3/_cy/unstable_vect.pyx
+++ b/src/h3/_cy/unstable_vect.pyx
@@ -1,5 +1,5 @@
 cimport h3lib
-from h3lib cimport H3int, H3Index
+from h3lib cimport H3int
 from .util cimport deg2coord
 
 from cython cimport boundscheck, wraparound
@@ -42,6 +42,7 @@ cpdef void haversine_vect(
                 p2.lat, p2.lng
             )
 
+
 @boundscheck(False)
 @wraparound(False)
 cpdef void geo_to_h3_vect(
@@ -58,14 +59,31 @@ cpdef void geo_to_h3_vect(
             c = deg2coord(lat[i], lng[i])
             out[i] = h3lib.geoToH3(&c, res)
 
+
 @boundscheck(False)
 @wraparound(False)
 cpdef void h3_to_parent_vect(
-    const H3Index[:] h,
-    int res,
-    H3Index[:] out
+    const H3int[:] h,
+    unsigned char[:] res,
+    H3int[:] out
 ) nogil:
+
+    cdef Py_ssize_t i
 
     with nogil:
         for i in range(len(h)):
-            out[i] = h3lib.h3ToParent(h[i], res)
+            out[i] = h3lib.h3ToParent(h[i], res[i])
+
+
+@boundscheck(False)
+@wraparound(False)
+cpdef void h3_get_resolution_vect(
+    const H3int[:] h,
+    unsigned char[:] out,
+) nogil:
+
+    cdef Py_ssize_t i
+
+    with nogil:
+        for i in range(len(h)):
+            out[i] = h3lib.h3GetResolution(h[i])

--- a/src/h3/_cy/unstable_vect.pyx
+++ b/src/h3/_cy/unstable_vect.pyx
@@ -1,5 +1,5 @@
 cimport h3lib
-from h3lib cimport H3int
+from h3lib cimport H3int, H3Index
 from .util cimport deg2coord
 
 from cython cimport boundscheck, wraparound
@@ -57,3 +57,17 @@ cpdef void geo_to_h3_vect(
         for i in range(len(lat)):
             c = deg2coord(lat[i], lng[i])
             out[i] = h3lib.geoToH3(&c, res)
+
+@boundscheck(False)
+@wraparound(False)
+cpdef void h3_to_parent_vect(
+    const H3Index[:] h,
+    int res,
+    H3Index[:] out
+):
+
+    # cdef H3Index c
+
+    for i in range(len(h)):
+        # c = h[i]
+        out[i] = h3lib.h3ToParent(h[i], res)

--- a/src/h3/_cy/unstable_vect.pyx
+++ b/src/h3/_cy/unstable_vect.pyx
@@ -64,7 +64,8 @@ cpdef void h3_to_parent_vect(
     const H3Index[:] h,
     int res,
     H3Index[:] out
-):
+) nogil:
 
-    for i in range(len(h)):
-        out[i] = h3lib.h3ToParent(h[i], res)
+    with nogil:
+        for i in range(len(h)):
+            out[i] = h3lib.h3ToParent(h[i], res)

--- a/src/h3/_cy/unstable_vect.pyx
+++ b/src/h3/_cy/unstable_vect.pyx
@@ -66,8 +66,5 @@ cpdef void h3_to_parent_vect(
     H3Index[:] out
 ):
 
-    # cdef H3Index c
-
     for i in range(len(h)):
-        # c = h[i]
         out[i] = h3lib.h3ToParent(h[i], res)

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -18,6 +18,7 @@ def h3_to_parent(h, res=None):
     -------
     array of H3Cells
     """
+    h = np.array(h, dtype=np.uint64)
     out = np.zeros(len(h), dtype=np.uint64)
 
     if res is None:
@@ -42,6 +43,7 @@ def h3_get_resolution(h):
     -------
     array of uint8
     """
+    h = np.array(h, dtype=np.uint64)
     out = np.zeros(len(h), dtype=np.uint8)
 
     _vect.h3_get_resolution_vect(h, out)
@@ -64,6 +66,9 @@ def geo_to_h3(lats, lngs, res):
     -------
     array of H3Cells
     """
+    lats = np.array(lats, dtype=np.float64)
+    lngs = np.array(lngs, dtype=np.float64)
+
     assert len(lats) == len(lngs)
 
     out = np.zeros(len(lats), dtype='uint64')
@@ -88,6 +93,8 @@ def cell_haversine(a, b):
     float
         Haversine distance in kilometers
     """
+    a = np.array(a, dtype=np.uint64)
+    b = np.array(b, dtype=np.uint64)
 
     assert len(a) == len(b)
 

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -41,7 +41,7 @@ def h3_get_resolution(h):
 
     Returns
     -------
-    array of uint8
+    array of int
     """
     h = np.array(h, dtype=np.uint64)
     out = np.zeros(len(h), dtype=np.intc)

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -24,7 +24,7 @@ def h3_to_parent(h, res=None):
     if res is None:
         res = h3_get_resolution(h) - 1
     else:
-        res = np.full(h.shape, res, dtype=np.int16)
+        res = np.full(h.shape, res, dtype=np.intc)
 
     _vect.h3_to_parent_vect(h, res, out)
 
@@ -44,7 +44,7 @@ def h3_get_resolution(h):
     array of uint8
     """
     h = np.array(h, dtype=np.uint64)
-    out = np.zeros(len(h), dtype=np.int16)
+    out = np.zeros(len(h), dtype=np.intc)
 
     _vect.h3_get_resolution_vect(h, out)
 

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -2,6 +2,7 @@ from .._cy import unstable_vect as _vect
 
 import numpy as np
 
+
 def h3_to_parent(h, res):
     """
     Get parent of arrays of cells
@@ -22,6 +23,7 @@ def h3_to_parent(h, res):
     _vect.h3_to_parent_vect(h, res, out)
 
     return out
+
 
 def geo_to_h3(lats, lngs, res):
     """

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -3,24 +3,48 @@ from .._cy import unstable_vect as _vect
 import numpy as np
 
 
-def h3_to_parent(h, res):
+def h3_to_parent(h, res=None):
     """
-    Get parent of arrays of cells
+    Get parent of arrays of cells.
 
     Parameters
     ----------
     h : array of H3Cells
-
-    res: int
-        Resolution for output cells.
+    res: int or None, optional
+        The resolution for the parent
+        If `None`, then `res = resolution(h) - 1`
 
     Returns
     -------
     array of H3Cells
     """
-    out = np.zeros(len(h), dtype='uint64')
+    out = np.zeros(len(h), dtype=np.uint64)
+
+    if res is None:
+        res = h3_get_resolution(h) - 1
+    else:
+        res = np.full(h.shape, res, dtype=np.uint8)
 
     _vect.h3_to_parent_vect(h, res, out)
+
+    return out
+
+
+def h3_get_resolution(h):
+    """
+    Return the resolution of an array of H3 cells.
+
+    Parameters
+    ----------
+    h : H3Cell
+
+    Returns
+    -------
+    array of uint8
+    """
+    out = np.zeros(len(h), dtype=np.uint8)
+
+    _vect.h3_get_resolution_vect(h, out)
 
     return out
 

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -24,7 +24,7 @@ def h3_to_parent(h, res=None):
     if res is None:
         res = h3_get_resolution(h) - 1
     else:
-        res = np.full(h.shape, res, dtype=np.uint8)
+        res = np.full(h.shape, res, dtype=np.int16)
 
     _vect.h3_to_parent_vect(h, res, out)
 
@@ -44,7 +44,7 @@ def h3_get_resolution(h):
     array of uint8
     """
     h = np.array(h, dtype=np.uint64)
-    out = np.zeros(len(h), dtype=np.uint8)
+    out = np.zeros(len(h), dtype=np.int16)
 
     _vect.h3_get_resolution_vect(h, out)
 

--- a/src/h3/unstable/vect.py
+++ b/src/h3/unstable/vect.py
@@ -2,10 +2,30 @@ from .._cy import unstable_vect as _vect
 
 import numpy as np
 
+def h3_to_parent(h, res):
+    """
+    Get parent of arrays of cells
+
+    Parameters
+    ----------
+    h : array of H3Cells
+
+    res: int
+        Resolution for output cells.
+
+    Returns
+    -------
+    array of H3Cells
+    """
+    out = np.zeros(len(h), dtype='uint64')
+
+    _vect.h3_to_parent_vect(h, res, out)
+
+    return out
 
 def geo_to_h3(lats, lngs, res):
     """
-    Convert arrays describing lat/lng paris to cells.
+    Convert arrays describing lat/lng pairs to cells.
 
     Parameters
     ----------

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -1,0 +1,42 @@
+import h3.api.numpy_int as h3
+import h3.unstable.vect as h3_vect
+import numpy as np  # only run this test suite if numpy is installed
+
+
+def test_h3_to_parent():
+    # At res 9
+    h = np.array([617700169958555647], np.uint64)
+
+    # Default to res - 1
+    arr1 = h3_vect.h3_to_parent(h)
+    arr2 = h3_vect.h3_to_parent(h, 8)
+    assert np.all(arr1 == arr2)
+
+    # Same as other h3 bindings
+    arr1 = h3_vect.h3_to_parent(h)
+    arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
+    assert np.all(arr1 == arr2)
+
+
+def test_h3_to_parent_multiple_res():
+    h = np.array([617700169958555647, 613196570331971583], np.uint64)
+
+    # Cells at res 9, 8
+    assert list(h3_vect.h3_get_resolution(h)) == [9, 8]
+
+    # Same as other h3 bindings
+    arr1 = h3_vect.h3_to_parent(h)
+    arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
+    assert np.all(arr1 == arr2)
+
+    # Parent cells are 8, 7
+    parents = h3_vect.h3_to_parent(h)
+    assert list(h3_vect.h3_get_resolution(parents)) == [8, 7]
+
+
+def test_h3_get_resolution():
+    h = np.array([617700169958555647], np.uint64)
+
+    arr1 = h3_vect.h3_get_resolution(h)
+    arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.uint8)
+    assert np.all(arr1 == arr2)

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -33,6 +33,11 @@ def test_h3_to_parent():
     assert np.array_equal(arr1, arr2)
     assert np.array_equal(arr1, np.array(arr3, dtype=np.uint64))
 
+    # Test with array-like (but not np.array) cell input
+    arr1 = h3_vect.h3_to_parent(list(h))
+    arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
+    assert np.array_equal(arr1, arr2)
+
 
 def test_h3_to_parent_multiple_res():
     h = np.array([617700169958555647, 613196570331971583], np.uint64)

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -23,7 +23,7 @@ def test_h3_to_parent():
     assert np.array_equal(arr1, arr2)
 
     # Test with an array passed to res
-    arr1 = h3_vect.h3_to_parent(h, np.array([7, 5], np.int16))
+    arr1 = h3_vect.h3_to_parent(h, np.array([7, 5], np.intc))
     arr2 = h3_vect.h3_to_parent(h, [7, 5])
 
     arr3 = []
@@ -59,5 +59,5 @@ def test_h3_get_resolution():
     h = np.array([617700169958555647], np.uint64)
 
     arr1 = h3_vect.h3_get_resolution(h)
-    arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.int16)
+    arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.intc)
     assert np.array_equal(arr1, arr2)

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -5,7 +5,7 @@ import numpy as np  # only run this test suite if numpy is installed
 
 def test_h3_to_parent():
     # At res 9
-    h = np.array([617700169958555647], np.uint64)
+    h = np.array([617700169958555647, 617700169958555647], np.uint64)
 
     # Default to res - 1
     arr1 = h3_vect.h3_to_parent(h)
@@ -16,6 +16,22 @@ def test_h3_to_parent():
     arr1 = h3_vect.h3_to_parent(h)
     arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
     assert np.array_equal(arr1, arr2)
+
+    # Test with a number passed to res
+    arr1 = h3_vect.h3_to_parent(h, 7)
+    arr2 = np.array([h3.h3_to_parent(c, 7) for c in h], dtype=np.uint64)
+    assert np.array_equal(arr1, arr2)
+
+    # Test with an array passed to res
+    arr1 = h3_vect.h3_to_parent(h, np.array([7, 5], np.uint8))
+    arr2 = h3_vect.h3_to_parent(h, [7, 5])
+
+    arr3 = []
+    for c, res in zip(h, [7, 5]):
+        arr3.append(h3.h3_to_parent(c, res))
+
+    assert np.array_equal(arr1, arr2)
+    assert np.array_equal(arr1, np.array(arr3, dtype=np.uint64))
 
 
 def test_h3_to_parent_multiple_res():

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -10,12 +10,12 @@ def test_h3_to_parent():
     # Default to res - 1
     arr1 = h3_vect.h3_to_parent(h)
     arr2 = h3_vect.h3_to_parent(h, 8)
-    assert np.all(arr1 == arr2)
+    assert np.array_equal(arr1, arr2)
 
     # Same as other h3 bindings
     arr1 = h3_vect.h3_to_parent(h)
     arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
-    assert np.all(arr1 == arr2)
+    assert np.array_equal(arr1, arr2)
 
 
 def test_h3_to_parent_multiple_res():
@@ -27,7 +27,7 @@ def test_h3_to_parent_multiple_res():
     # Same as other h3 bindings
     arr1 = h3_vect.h3_to_parent(h)
     arr2 = np.array(list(map(h3.h3_to_parent, h)), dtype=np.uint64)
-    assert np.all(arr1 == arr2)
+    assert np.array_equal(arr1, arr2)
 
     # Parent cells are 8, 7
     parents = h3_vect.h3_to_parent(h)
@@ -39,4 +39,4 @@ def test_h3_get_resolution():
 
     arr1 = h3_vect.h3_get_resolution(h)
     arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.uint8)
-    assert np.all(arr1 == arr2)
+    assert np.array_equal(arr1, arr2)

--- a/tests/test_unstable_vect.py
+++ b/tests/test_unstable_vect.py
@@ -23,7 +23,7 @@ def test_h3_to_parent():
     assert np.array_equal(arr1, arr2)
 
     # Test with an array passed to res
-    arr1 = h3_vect.h3_to_parent(h, np.array([7, 5], np.uint8))
+    arr1 = h3_vect.h3_to_parent(h, np.array([7, 5], np.int16))
     arr2 = h3_vect.h3_to_parent(h, [7, 5])
 
     arr3 = []
@@ -59,5 +59,5 @@ def test_h3_get_resolution():
     h = np.array([617700169958555647], np.uint64)
 
     arr1 = h3_vect.h3_get_resolution(h)
-    arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.uint8)
+    arr2 = np.array(list(map(h3.h3_get_resolution, h)), dtype=np.int16)
     assert np.array_equal(arr1, arr2)


### PR DESCRIPTION
This PR adds a simple vectorized `h3_to_parent`, along the lines of #147 . I compared this to a simple loop that repeatedly calls `h3.h3_to_parent` and found a 160x speedup over pure Python and 100x faster than `np.vectorize`.

I'd love to add a vectorized complement to every h3 API function, but that would create a lot of duplication, as presumably every function would need a for loop in Cython, so you couldn't use the `_api_template` setup to add vectorized functions.

```py
import h3.api.numpy_int as h3
import h3.unstable.vect as vect
import numpy as np

N = 100_000
K = 10

lats, longs = np.random.uniform(0, 90, N), np.random.uniform(0, 90, N)
h3_index = vect.geo_to_h3(lats, longs, 9)

%%timeit
out_loop = []
for i in range(len(h3_index)):
    out_loop.append(h3.h3_to_parent(h3_index[i], 8))
# 67.6 ms ± 2.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

vec_fn = np.vectorize(h3.h3_to_parent)
%timeit vec_fn(h3_index, 8)
# 42.6 ms ± 1.23 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit out_vect = vect.h3_to_parent(h3_index, 8)
# 423 µs ± 15.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

np.array_equal(out_loop, out_vect)
# True
```

cc @isaacbrodsky 