### PR TITLE
h3-py release v3.7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         exclude:
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
         exclude:
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
 
       ## Start Windows stuff
-      - uses: ilammy/msvc-dev-cmd@v1.3.0
+      - uses: ilammy/msvc-dev-cmd@v1.5.0
         if: startsWith(matrix.os, 'windows')
 
       - name: Set Windows Compiler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         exclude:
           - os: windows-latest
             python-version: 2.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Set Windows Compiler
         if: startsWith(matrix.os, 'windows')
         run: |
-          echo "::set-env name=CC::cl.exe"
-          echo "::set-env name=CXX::cl.exe"
+          echo "CC=cl.exe" >> $GITHUB_ENV
+          echo "CXX=cl.exe" >> $GITHUB_ENV
       ## End Windows stuff
 
       - name: Install from source

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build Mac
         if: startsWith(matrix.os, 'mac')
         env:
-          CIBW_SKIP: pp* cp39-*
+          CIBW_SKIP: pp*
         run: |
           python -m cibuildwheel --output-dir wheelhouse
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: 3.8
 
-      - uses: ilammy/msvc-dev-cmd@v1.3.0
+      - uses: ilammy/msvc-dev-cmd@v1.5.0
         if: startsWith(matrix.os, 'windows')
 
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Because H3-Py is versioned in lockstep with the H3 core library, please
 avoid adding features or APIs which do not map onto the
 [H3 core API](https://uber.github.io/h3/#/documentation/api-reference/).
 
+## unreleased
+
+- bump h3lib version to v3.7.1
+
 ## [3.7.0] - 2020-10-02
 
 - Add functions (#171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ avoid adding features or APIs which do not map onto the
 
 ## unreleased
 
-- fix for #169: `h3_distance` error reporting
-- build Python 3.9 wheel for Mac
-- bump h3lib version to v3.7.1
+## [3.7.1] - 2020-12-18
+
+- fix for #169: `h3_distance` error reporting (#175)
+- build Python 3.9 wheel for Mac (#175)
+- bump h3lib version to v3.7.1 (#175)
 
 ## [3.7.0] - 2020-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ avoid adding features or APIs which do not map onto the
 
 ## unreleased
 
+- build Python 3.9 wheel for Mac
 - bump h3lib version to v3.7.1
 
 ## [3.7.0] - 2020-10-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ avoid adding features or APIs which do not map onto the
 
 ## unreleased
 
+- fix for #169: `h3_distance` error reporting
 - build Python 3.9 wheel for Mac
 - bump h3lib version to v3.7.1
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -33,3 +33,13 @@ cd ..
 git add h3lib
 git commit ...
 ```
+
+for a specific version tag:
+
+```sh
+cd src/h3lib
+git checkout v3.7.1  # or whatever version tag you'd like
+cd ..
+git add h3lib
+git commit ...
+```

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 
 init: purge
 	git submodule update --init
-	virtualenv -p python3 env
+	python -m venv env
 	env/bin/pip install .[all]
 
 clear:

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/h3.svg)](https://badge.fury.io/py/h3)
 [![PyPI downloads](https://pypip.in/d/h3/badge.png)](https://pypistats.org/packages/h3)
 [![conda](https://img.shields.io/conda/vn/conda-forge/h3-py.svg)](https://anaconda.org/conda-forge/h3-py)
-[![version](https://img.shields.io/badge/h3-v3.7.0-blue.svg)](https://github.com/uber/h3/releases/tag/v3.7.0)
+[![version](https://img.shields.io/badge/h3-v3.7.1-blue.svg)](https://github.com/uber/h3/releases/tag/v3.7.1)
 [![version](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 [![Tests](https://github.com/uber/h3-py/workflows/tests/badge.svg)](https://github.com/uber/h3-py/actions)

--- a/src/h3/_cy/cells.pyx
+++ b/src/h3/_cy/cells.pyx
@@ -52,6 +52,11 @@ cpdef int distance(H3int h1, H3int h2) except -1:
 
     d = h3lib.h3Distance(h1,h2)
 
+    # if d < 0:
+    #     s = 'Cells are too far apart to compute distance: {} and {}'
+    #     s = s.format(hex(h1), hex(h2))
+    #     raise H3ValueError(s)
+
     return d
 
 cpdef H3int[:] disk(H3int h, int k):

--- a/src/h3/_cy/cells.pyx
+++ b/src/h3/_cy/cells.pyx
@@ -52,10 +52,10 @@ cpdef int distance(H3int h1, H3int h2) except -1:
 
     d = h3lib.h3Distance(h1,h2)
 
-    # if d < 0:
-    #     s = 'Cells are too far apart to compute distance: {} and {}'
-    #     s = s.format(hex(h1), hex(h2))
-    #     raise H3ValueError(s)
+    if d < 0:
+        s = 'Cells are too far apart to compute distance: {} and {}'
+        s = s.format(hex(h1), hex(h2))
+        raise H3ValueError(s)
 
     return d
 

--- a/src/h3/_version.py
+++ b/src/h3/_version.py
@@ -1,4 +1,4 @@
-__version__ = '3.7.0'
+__version__ = '3.7.1'
 __description__ = 'Hierarchical hexagonal geospatial indexing system'
 __url__ = 'https://github.com/uber/h3-py'
 __license__ = "Apache 2.0 License"

--- a/src/h3/_version.py
+++ b/src/h3/_version.py
@@ -16,6 +16,7 @@ __classifiers__ = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",

--- a/src/h3/api/_api_template.py
+++ b/src/h3/api/_api_template.py
@@ -247,6 +247,9 @@ def _api_functions(
         path between the cells in the graph formed by connecting
         adjacent cells.
 
+        This function will return an H3ValueError if the
+        cells are too far apart to compute the distance.
+
         Parameters
         ----------
         h1 : H3Cell

--- a/tests/test_cells_and_edges.py
+++ b/tests/test_cells_and_edges.py
@@ -195,6 +195,14 @@ def test_distance():
     assert h3.h3_distance(h, n) == 2
 
 
+def test_distance_error():
+    h1 = '8353b0fffffffff'
+    h2 = '835804fffffffff'
+
+    with pytest.raises(H3ValueError):
+        h3.h3_distance(h1, h2)
+
+
 def test_compact():
 
     # lat/lngs for State of Maine


### PR DESCRIPTION
- fix for #169: `h3_distance` error reporting
- build Python 3.9 wheel for Mac
- bump h3lib version to v3.7.1

Closes #169 and #174