### PR TITLE
Run CI Tests on 3.10, remove Python 3.5 Windows test/wheel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10"]
         exclude:
           - os: windows-latest
             python-version: 2.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: 2.7
+          - os: windows-latest
+            python-version: 3.5
 
     steps:
       - uses: actions/checkout@v2.3.3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
           name: macOS Intel
         - os: windows-latest
           build: "cp3*-win_amd64"
-          skip: "cp35-win_am64"
+          skip: "cp35-win_amd64"
           name: Windows 64-bit
         - os: ubuntu-latest
           build: "cp*-manylinux_x86_64"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,6 +42,7 @@ jobs:
           name: macOS Intel
         - os: windows-latest
           build: "cp3*-win_amd64"
+          skip: "cp35-win_am64"
           name: Windows 64-bit
         - os: ubuntu-latest
           build: "cp*-manylinux_x86_64"
@@ -91,6 +92,7 @@ jobs:
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD: ${{ matrix.build }}
+          CIBW_SKIP: ${{ matrix.skip }}
 
       - name: Check with Twine
         run: |


### PR DESCRIPTION
It seems from #213 that some CI runs are failing that shouldn't be related to that PR's changes, e.g. tests and wheel builds on Windows on Python 3.5. I'm using this PR to test this apart from any other changes.

### Change list

- Run tests on Python 3.10
- Don't run tests on Python 3.5 on Windows
- Don't build wheel for Python 3.5 on Windows