### PR TITLE
Add linux aarch wheel for Python 3.10

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -92,6 +92,9 @@ jobs:
           - os: ubuntu-latest
             build: "cp39-manylinux_aarch64"
             name: Linux Aarch64 3.9
+          - os: ubuntu-latest
+            build: "cp310-manylinux_aarch64"
+            name: Linux Aarch64 3.10
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This adds a new job to create a linux aarch wheel (`cp310-manylinux_aarch64`) for Python 3.10.

I assume that these aarch wheels are listed as their own jobs because they take longer to build. Judging from CI times, it takes roughly 15 minutes to build each aarch wheel, so if all five Python versions were built as a single job, that would take 75 minutes, which is too long for CI that runs on every PR.