### PR TITLE
Build Cython annotations for perf analysis

### DIFF
--- a/.github/workflows/coverage-lint.yml
+++ b/.github/workflows/coverage-lint.yml
@@ -41,3 +41,13 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
+
+      - name: Copy Cython annotations to project dir
+        run: |
+          mkdir annotations
+          cp _skbuild/*/cmake-build/src/h3/_cy/*.html ./annotations
+
+      - name: Upload artifacts to GitHub
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./annotations

--- a/src/h3/_cy/CMakeLists.txt
+++ b/src/h3/_cy/CMakeLists.txt
@@ -3,6 +3,9 @@ find_package(PythonExtensions MODULE REQUIRED)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+# Build Cython annotations
+set(CYTHON_ANNOTATE TRUE)
+
 macro(add_cython_file filename)
     add_cython_target(${filename} C PY3)
     add_library(${filename} MODULE ${filename} ${LIB_SOURCE_FILES} ${CONFIGURED_API_HEADER})


### PR DESCRIPTION
Cython annotations are crucial for benchmarking and analyzing cython performance because they show you where it's important to add Cython type hints: https://cython.readthedocs.io/en/latest/src/quickstart/cythonize.html#determining-where-to-add-types. Ref: https://github.com/uber/h3-py/pull/224#issuecomment-1105823797

Scikit-build [allows us](https://scikit-build.readthedocs.io/en/latest/cmake-modules/Cython.html) to set `CYTHON_ANNOTATE` to `true`. On my computer this outputs these files after `pip install`:
```
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/unstable_vect.html
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/util.html
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/geo.html
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/edges.html
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/cells.html
./_skbuild/macosx-11.0-x86_64-3.8/cmake-build/src/h3/_cy/to_multipoly.html
```

This also updates the CI to copy these annotations on each CI run.