### PR TITLE
Expose cython API for internal use

### DIFF
--- a/src/h3/_cy/cells.pxd
+++ b/src/h3/_cy/cells.pxd
@@ -8,7 +8,7 @@ cpdef int distance(H3int h1, H3int h2) except -1
 cpdef H3int[:] disk(H3int h, int k)
 cpdef H3int[:] _ring_fallback(H3int h, int k)
 cpdef H3int[:] ring(H3int h, int k)
-cpdef H3int parent(H3int h, int res=*) except 0
+cpdef H3int parent(H3int h, res=*) except 0
 cpdef H3int[:] children(H3int h, res=*)
 cpdef H3int center_child(H3int h, res=*) except 0
 cpdef H3int[:] compact(const H3int[:] hu)

--- a/src/h3/_cy/cells.pxd
+++ b/src/h3/_cy/cells.pxd
@@ -1,0 +1,25 @@
+from .h3lib cimport bool, int64_t, H3int
+
+cpdef bool is_cell(H3int h)
+cpdef bool is_pentagon(H3int h)
+cpdef int get_base_cell(H3int h) except -1
+cpdef int resolution(H3int h) except -1
+cpdef int distance(H3int h1, H3int h2) except -1
+cpdef H3int[:] disk(H3int h, int k)
+cpdef H3int[:] _ring_fallback(H3int h, int k)
+cpdef H3int[:] ring(H3int h, int k)
+cpdef H3int parent(H3int h, int res=*) except 0
+cpdef H3int[:] children(H3int h, res=*)
+cpdef H3int center_child(H3int h, res=*) except 0
+cpdef H3int[:] compact(const H3int[:] hu)
+cpdef H3int[:] uncompact(const H3int[:] hc, int res)
+cpdef int64_t num_hexagons(int resolution) except -1
+cpdef double mean_hex_area(int resolution, unit=*) except -1
+cpdef double cell_area(H3int h, unit=*) except -1
+cpdef H3int[:] line(H3int start, H3int end)
+cpdef bool is_res_class_iii(H3int h)
+cpdef H3int[:] get_pentagon_indexes(int res)
+cpdef H3int[:] get_res0_indexes()
+cpdef get_faces(H3int h)
+cpdef (int, int) experimental_h3_to_local_ij(H3int origin, H3int h) except *
+cpdef H3int experimental_local_ij_to_h3(H3int origin, int i, int j) except 0

--- a/src/h3/_cy/edges.pxd
+++ b/src/h3/_cy/edges.pxd
@@ -1,0 +1,11 @@
+from .h3lib cimport bool, H3int
+
+cpdef bool are_neighbors(H3int h1, H3int h2)
+cpdef H3int edge(H3int origin, H3int destination) except 1
+cpdef bool is_edge(H3int e)
+cpdef H3int edge_origin(H3int e) except 1
+cpdef H3int edge_destination(H3int e) except 1
+cpdef (H3int, H3int) edge_cells(H3int e) except *
+cpdef H3int[:] edges_from_cell(H3int origin)
+cpdef double mean_edge_length(int resolution, unit=*) except -1
+cpdef double edge_length(H3int e, unit=*) except -1

--- a/src/h3/_cy/geo.pxd
+++ b/src/h3/_cy/geo.pxd
@@ -1,0 +1,7 @@
+from .h3lib cimport H3int
+
+cpdef H3int geo_to_h3(double lat, double lng, int res) except 1
+cpdef (double, double) h3_to_geo(H3int h) except *
+cpdef double point_dist(
+    double lat1, double lng1,
+    double lat2, double lng2, unit=*) except -1


### PR DESCRIPTION
### Change list

- Add `.pxd` Cython definitions so that `cells.pyx`, `edges.pyx`, and `geo.pyx` can be imported by other internal Cython files.

Replaces https://github.com/uber/h3-py/pull/224