### PR TITLE
Makefile step to copy annotations locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ h3c/
 .cache/
 h3/out/
 
+# Cython HTML annotations
+*.html
+
 # C extensions
 *.so
 

--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ init: purge
 clear:
 	-env/bin/pip uninstall -y h3
 	-@rm -rf MANIFEST
+	-@rm -rf annotations
 	-@rm -rf .pytest_cache tests/__pycache__ __pycache__ _skbuild dist .coverage
 	-@find . -type d -name '*.egg-info' | xargs rm -r
 	-@find . -type f -name '*.pyc' | xargs rm -r
@@ -28,6 +29,10 @@ rebuild: clear
 
 purge: clear
 	-@rm -rf env
+
+annotations: rebuild
+	mkdir -p annotations
+	cp _skbuild/*/cmake-build/src/h3/_cy/*.html ./annotations
 
 test:
 	env/bin/pytest tests/* --cov=h3 --cov-report term-missing --durations=10


### PR DESCRIPTION
### Change list

- Adds an `annotations` target to the Makefile to copy generated Cython annotations into a top-level `annotations/` folder.
- Adds `.html` to gitignore