### PR TITLE
Get the makefile working on Linux

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,21 +1,23 @@
 .PHONY: init clear rebuild purge test lint lab ipython
 
+PYTHON=$(shell command -v python || command -v python3)
+
 
 build-docs:
-	env/bin/jupyter-book build docs/ --warningiserror --keep-going --all
+	./env/bin/jupyter-book build docs/ --warningiserror --keep-going --all
 
 open:
 	open docs/_build/html/index.html
 
 init: purge
 	git submodule update --init
-	python -m venv env
-	env/bin/pip install --upgrade pip wheel setuptools
-	env/bin/pip install .[all]
-	env/bin/pip install -r requirements.in
+	$(PYTHON) -m venv env
+	./env/bin/pip install --upgrade pip wheel setuptools
+	./env/bin/pip install .[all]
+	./env/bin/pip install -r requirements.in
 
 clear:
-	-env/bin/pip uninstall -y h3
+	-./env/bin/pip uninstall -y h3
 	-@rm -rf MANIFEST
 	-@rm -rf annotations
 	-@rm -rf .pytest_cache tests/__pycache__ __pycache__ _skbuild dist .coverage
@@ -25,7 +27,7 @@ clear:
 	-@find ./tests -type f -name '*.c' | xargs rm -r
 
 rebuild: clear
-	env/bin/pip install .[all]
+	./env/bin/pip install .[all]
 
 purge: clear
 	-@rm -rf env
@@ -35,13 +37,13 @@ annotations: rebuild
 	cp _skbuild/*/cmake-build/src/h3/_cy/*.html ./annotations
 
 test:
-	env/bin/cythonize -i tests/cython_example.pyx
-	env/bin/pytest tests --cov=h3 --cov-report term-missing --durations=10
+	./env/bin/cythonize -i tests/cython_example.pyx
+	./env/bin/pytest tests --cov=h3 --cov-report term-missing --durations=10
 
 lint:
-	env/bin/flake8 src/h3 setup.py tests
-	env/bin/pylint --disable=all --enable=import-error tests/
+	./env/bin/flake8 src/h3 setup.py tests
+	./env/bin/pylint --disable=all --enable=import-error tests/
 
 lab:
-	env/bin/pip install jupyterlab
-	env/bin/jupyter lab
+	./env/bin/pip install jupyterlab
+	./env/bin/jupyter lab


### PR DESCRIPTION
On many Linuxes, particularly Debian-derived ones, the Python 3 binary is `python3` instead of just `python` for weird legacy reasons, so added some logic to detect which python binary to use. Also switched all of the `env/bin/<foo>` calls to `./env/bin/<foo>` since the former only works if you have the current working directory in your `$PATH`, which is a major security no-no and I would be surprised if MacOS has that on by default (I think you guys must have accidentally added that to your shell setup).