### PR TITLE
Fix broken example in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ conda install h3-py
 >>> import h3
 >>> lat, lng = 37.769377, -122.388903
 >>> resolution = 9
->>> h3.latlng_to_cell(lat, lng, resolution)
+>>> h3.geo_to_h3(lat, lng, resolution)
 '89283082e73ffff'
 ```
 


### PR DESCRIPTION
When running through the simple example in the README, I get an error when trying to call ``latlng_to_cell``:

> AttributeError: module 'h3' has no attribute 'latlng_to_cell'

Looking at the python h3 API, this method is missing, but instead ``geo_to_h3`` produces an identical result to the example originally provided.

Versions in use:

![image](https://user-images.githubusercontent.com/178003/194762475-e4b69802-8409-455b-851e-fef02f2d555c.png)
