### PR TITLE
Drop 2.7 tests and avoid Cython warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04]
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
-        exclude:
-          - os: windows-latest
-            python-version: 2.7
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
           - os: windows-latest
             python-version: 3.5
 

--- a/tests/cython_example.pyx
+++ b/tests/cython_example.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 from cython cimport boundscheck, wraparound
 
 from h3._cy.h3lib cimport H3int


### PR DESCRIPTION
Set language level to avoid:

```
[1/1] Cythonizing /Users/ajfriend/work/h3-py/tests/cython_example.pyx
/Users/ajfriend/work/h3-py/env/lib/python3.11/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /Users/ajfriend/work/h3-py/tests/cython_example.pyx
```

Also, drop Python 2.7 from test matrix.