### PR TITLE
Add python 3.12 wheels on v3.7

### DIFF
--- a/.github/workflows/coverage-lint.yml
+++ b/.github/workflows/coverage-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tests:
     name: Coverage and Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install from source
         run: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-python@v4.3.0
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           - os: windows-latest
             python-version: 2.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          - os: windows-latest
-            python-version: 2.7
+        os: [macos-latest, windows-latest, ubuntu-20.04]
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
           - os: windows-latest
             python-version: 3.5
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04]
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-          - os: windows-latest
-            python-version: 3.5
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +35,6 @@ jobs:
           echo "CC=cl.exe" >> $GITHUB_ENV
           echo "CXX=cl.exe" >> $GITHUB_ENV
       ## End Windows stuff
-
       - name: Install from source
         run: |
           pip install --upgrade pip setuptools wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -109,7 +109,7 @@ jobs:
 
       ## Build
 
-      - uses: pypa/cibuildwheel@v2.16.2
+      - uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -66,9 +66,6 @@ jobs:
             build: "cp*-musllinux_x86_64"
             name: Linux Intel musl 64-bit
           - os: ubuntu-latest
-            build: "cp36-manylinux_aarch64"
-            name: Linux Aarch64 3.6
-          - os: ubuntu-latest
             build: "cp37-manylinux_aarch64"
             name: Linux Aarch64 3.7
           - os: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,44 +46,6 @@ jobs:
         with:
           path: ./dist
 
-  make_cibw_v1_wheels:
-    name: "cibuildwheel v1: ${{ matrix.name }}"
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # Only build for platforms that cibw v2 doesn't support
-        include:
-          - os: macos-latest
-            build: "cp27-macosx_x86_64"
-            name: macOS Intel
-          - os: ubuntu-latest
-            build: "cp27-manylinux_x86_64"
-            name: Linux Intel 64-bit
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      ## Build
-
-      - uses: pypa/cibuildwheel@v1.12.0
-        env:
-          CIBW_TEST_REQUIRES: pytest numpy
-          CIBW_TEST_COMMAND: pytest {project}/tests
-          CIBW_ARCHS_LINUX: auto aarch64
-          CIBW_BUILD: ${{ matrix.build }}
-
-      - name: Check with Twine
-        run: |
-          pipx run twine check wheelhouse/*
-
-      - name: Upload artifacts to GitHub
-        uses: actions/upload-artifact@v3
-        with:
-          path: wheelhouse/*.whl
-
   make_cibw_v2_wheels:
     name: "cibuildwheel v2: ${{ matrix.name }}"
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
@@ -150,7 +112,7 @@ jobs:
 
       ## Build
 
-      - uses: pypa/cibuildwheel@v2.16.5
+      - uses: pypa/cibuildwheel@v2.16.2
         env:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
@@ -169,8 +131,8 @@ jobs:
           path: wheelhouse/*.whl
 
   upload_all:
-    needs: [make_sdist, make_cibw_v1_wheels, make_cibw_v2_wheels]
-    runs-on: ubuntu-latest
+    needs: [make_sdist, make_cibw_v2_wheels]
+    runs-on: ubuntu-20.04
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -121,6 +121,9 @@ jobs:
           - os: ubuntu-latest
             build: "cp311-manylinux_aarch64"
             name: Linux Aarch64 3.11
+          - os: ubuntu-latest
+            build: "cp312-manylinux_aarch64"
+            name: Linux Aarch64 3.12
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -150,7 +150,7 @@ jobs:
 
       ## Build
 
-      - uses: pypa/cibuildwheel@v2.11.2
+      - uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_TEST_REQUIRES: pytest numpy
           CIBW_TEST_COMMAND: pytest {project}/tests

--- a/src/h3/_version.py
+++ b/src/h3/_version.py
@@ -19,6 +19,7 @@ __classifiers__ = [
     "Programming Language :: Python :: 3.9",
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Extend the exisiting build pipeline to create python 3.12 wheels.