### PR TITLE
release to test PyPI upload works after artifact changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ avoid adding features or APIs which do not map onto the
 
 ## [4.0.0b4] - 2024-04-14
 
-No changes.
+No changes, just testing: #360
 
 ## [4.0.0b3] - 2024-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ avoid adding features or APIs which do not map onto the
 
 - None
 
+## [4.0.0b4] - 2024-04-14
+
+No changes.
+
 ## [4.0.0b3] - 2024-03-11
 
 - Change supported Python versions to 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 (#324, #325, #347, #348)

--- a/src/h3/_version.py
+++ b/src/h3/_version.py
@@ -1,4 +1,4 @@
-__version__ = '4.0.0b3'
+__version__ = '4.0.0b4'
 __description__ = 'Hierarchical hexagonal geospatial indexing system'
 __url__ = 'https://github.com/uber/h3-py'
 __license__ = 'Apache 2.0 License'


### PR DESCRIPTION
We updated the `upload-artifact` and `download-artifact` actions to v4 in #355, so I'm doing a simple beta release to test that the PyPI upload is still working properly.