### PR TITLE
Handle polygons with z-coordinate

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,4 +15,6 @@ ignore =
     # E731 do not assign a lambda expression, use a def
     E731,
     # https://stackoverflow.com/questions/67942075/w504-line-break-after-binary-operator
-    W503,W504
+    W503,W504,
+    # E272 multiple spaces before keyword
+    E272

--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -214,8 +214,8 @@ def _LL3_to_mpoly(ll3):
     return mpoly
 
 
-def _polygon_to_LL2(LatLngPoly):
-    ll2 = [LatLngPoly.outer] + list(LatLngPoly.holes)
+def _polygon_to_LL2(poly):
+    ll2 = [poly.outer] + list(poly.holes)
     ll2 = tuple(
         _close_ring(_swap_latlng(ll1))
         for ll1 in ll2

--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -219,7 +219,16 @@ def _polygon_to_LL2(LatLngPoly):
     return ll2
 
 
+def remove_z(ll1):
+    ll1 = [(a,b) for a, b, *z in ll1]
+    return ll1
+
 def _LL2_to_polygon(ll2):
+    ll2 = [
+        remove_z(ll1)
+        for ll1 in ll2
+    ]
+
     ll2 = [
         _swap_latlng(ll1)
         for ll1 in ll2

--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -57,6 +57,11 @@ class LatLngPoly(H3Shape):
             if len(loop) in (1, 2):
                 raise ValueError('Non-empty LatLngPoly loops need at least 3 points.')
 
+            point_dimensions = set(map(len, loop))
+            # empty set is possible for empty polygons, so we check if a subset
+            if not (point_dimensions <= {2}):
+                raise ValueError('LatLngPoly only accepts 2D points: lat/lng.')
+
         self.outer = tuple(_open_ring(outer))
         self.holes = tuple(
             _open_ring(hole)
@@ -219,13 +224,14 @@ def _polygon_to_LL2(LatLngPoly):
     return ll2
 
 
-def remove_z(ll1):
-    ll1 = [(a,b) for a, b, *z in ll1]
+def _remove_z(ll1):
+    ll1 = [(a, b) for a, b, *z in ll1]
     return ll1
+
 
 def _LL2_to_polygon(ll2):
     ll2 = [
-        remove_z(ll1)
+        _remove_z(ll1)
         for ll1 in ll2
     ]
 

--- a/tests/polyfill/test_h3.py
+++ b/tests/polyfill/test_h3.py
@@ -387,7 +387,7 @@ def test_multipoly_checks():
         h3.LatLngMultiPoly([[(1, 2), (3, 4)]])
 
 
-def test_z_coord():
+def test_3d_geo():
     loop = lnglat_open()
 
     loop2d = [(lng, lat)      for lng, lat in loop]
@@ -407,6 +407,7 @@ def test_z_coord():
 
 
 def test_against_3d_polygons():
+    # LatLngPoly still expects just a lat/lng. it won't handle 3d coords
     loop3d = [
         (lat, lng, 0.0)
         for lat, lng in latlng_open()

--- a/tests/polyfill/test_h3.py
+++ b/tests/polyfill/test_h3.py
@@ -404,3 +404,13 @@ def test_z_coord():
 
     assert len(out2) == 344
     assert set(out2) == set(out3)
+
+
+def test_against_3d_polygons():
+    loop3d = [
+        (lat, lng, 0.0)
+        for lat, lng in latlng_open()
+    ]
+
+    with pytest.raises(ValueError):
+        h3.LatLngPoly(loop3d)

--- a/tests/polyfill/test_h3.py
+++ b/tests/polyfill/test_h3.py
@@ -385,3 +385,17 @@ def test_multipoly_checks():
 
     with pytest.raises(ValueError):
         h3.LatLngMultiPoly([[(1, 2), (3, 4)]])
+
+def test_z_coord():
+    loop = [
+        [37.813, -122.408, 0.0],
+        [37.707, -122.512, 0.0],
+        [37.815, -122.479, 0.0],
+    ]
+
+    geo = get_mocked(loop)
+    shape = h3.geo_to_h3shape(geo)
+
+    out = h3.h3shape_to_cells(shape, 9)
+    assert len(out) > 300
+    # todo: maybe compare that the cells are the same when you do the 2d version

--- a/tests/polyfill/test_h3.py
+++ b/tests/polyfill/test_h3.py
@@ -388,10 +388,10 @@ def test_multipoly_checks():
 
 
 def test_z_coord():
-    loop = latlng_open()
+    loop = lnglat_open()
 
-    loop2d = [(lat, lng)      for lat, lng in loop]
-    loop3d = [(lat, lng, 0.0) for lat, lng in loop]
+    loop2d = [(lng, lat)      for lng, lat in loop]
+    loop3d = [(lng, lat, 0.0) for lng, lat in loop]
 
     geo2d = get_mocked(loop2d)
     geo3d = get_mocked(loop3d)
@@ -402,5 +402,5 @@ def test_z_coord():
     out2 = h3.h3shape_to_cells(shape2, 9)
     out3 = h3.h3shape_to_cells(shape3, 9)
 
-    assert len(out2) > 300
+    assert len(out2) == 344
     assert set(out2) == set(out3)

--- a/tests/polyfill/test_h3.py
+++ b/tests/polyfill/test_h3.py
@@ -386,16 +386,21 @@ def test_multipoly_checks():
     with pytest.raises(ValueError):
         h3.LatLngMultiPoly([[(1, 2), (3, 4)]])
 
+
 def test_z_coord():
-    loop = [
-        [37.813, -122.408, 0.0],
-        [37.707, -122.512, 0.0],
-        [37.815, -122.479, 0.0],
-    ]
+    loop = latlng_open()
 
-    geo = get_mocked(loop)
-    shape = h3.geo_to_h3shape(geo)
+    loop2d = [(lat, lng)      for lat, lng in loop]
+    loop3d = [(lat, lng, 0.0) for lat, lng in loop]
 
-    out = h3.h3shape_to_cells(shape, 9)
-    assert len(out) > 300
-    # todo: maybe compare that the cells are the same when you do the 2d version
+    geo2d = get_mocked(loop2d)
+    geo3d = get_mocked(loop3d)
+
+    shape2 = h3.geo_to_h3shape(geo2d)
+    shape3 = h3.geo_to_h3shape(geo3d)
+
+    out2 = h3.h3shape_to_cells(shape2, 9)
+    out3 = h3.h3shape_to_cells(shape3, 9)
+
+    assert len(out2) > 300
+    assert set(out2) == set(out3)


### PR DESCRIPTION
Make it so that we drop the Z coordinate (if it is present) when translating from a `__geo_interface__` object. `LatLngPoly` will still always expect just 2 coordinates in each point.

Closes https://github.com/uber/h3-py/issues/368