### PR TITLE
Fix loose files during install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 # MANIFEST.in commands specified here:
 # https://packaging.python.org/en/latest/guides/using-manifest-in/#manifest-in-commands
 
+prune docs/
+prune .github/
+
 include CHANGELOG.md
 include CMakeLists.txt
 include LICENSE
@@ -22,3 +25,4 @@ include src/h3lib/CMakeLists.txt
 graft src/h3lib/cmake
 graft src/h3lib/src/h3lib
 exclude MANIFEST.in
+exclude .*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,5 @@ requires = [
     'scikit-build',
     'cython',
     'cmake',
+    'setuptools-scm',
 ]


### PR DESCRIPTION
To solve https://github.com/uber/h3-py/issues/374

[Updated since first review]
It turns out the solution is much simpler than originally thought!

Now we use `setuptools-scm` for better file discovery and path management.

Added the following lines to `MANIFEST.in` to exclude some newly included folders (were originally excluded)
```
prune docs/
prune .github/
...
exclude .*  # .gitignore etc
```

There are about 20 extra files in the sdist compared to the current master. They are mostly files in the subfolders of `tests/`

I have checked with pip-installing `.`, sdist and wheel. They all work fine:
that is, no stray source files outside `site-packages/h3` 


