### PR TITLE
Support `str`-like values for str_to_int

### DIFF
--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -53,7 +53,7 @@ def str_to_int(h):
     int
         Unsigned 64-bit integer
     """
-    return _cy.str_to_int(h)
+    return _cy.str_to_int(str(h))
 
 
 def int_to_str(x):

--- a/tests/test_apis/test_numpy_int.py
+++ b/tests/test_apis/test_numpy_int.py
@@ -5,7 +5,10 @@ from .. import util as u
 
 
 def test1():
-    lat, lng = 37.7752702151959, -122.418307270836,
+    lat, lng = (
+        37.7752702151959,
+        -122.418307270836,
+    )
     assert h3.latlng_to_cell(lat, lng, 9) == 617700169958293503
 
 
@@ -31,3 +34,19 @@ def test_compact_cells():
     assert isinstance(cells, np.ndarray)
 
     assert h3.compact_cells(cells) == [h]
+
+
+def test_numpy_str():
+    expected = [
+        617700169957507071,
+        617700169957769215,
+        617700169958031359,
+        617700169958293503,
+        617700169961177087,
+        617700169964847103,
+        617700169965109247,
+    ]
+    cells = np.array([h3.int_to_str(h) for h in expected])
+    got = [h3.str_to_int(c) for c in cells]
+
+    assert expected == got


### PR DESCRIPTION
Since `numpy>=2` (?), `str` values are not native `str` but `numpy.str_`. 

Without the explicit conversion to `str`, the test fails with:


```
================================================== FAILURES ===================================================
_______________________________________________ test_numpy_str ________________________________________________

    def test_numpy_str():
        expected = [
            617700169957507071,
            617700169957769215,
            617700169958031359,
            617700169958293503,
            617700169961177087,
            617700169964847103,
            617700169965109247,
        ]
        cells = np.array([h3.int_to_str(h) for h in expected])
>       got = [h3.str_to_int(c) for c in cells]

tests/test_apis/test_numpy_int.py:50:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/test_apis/test_numpy_int.py:50: in <listcomp>
    got = [h3.str_to_int(c) for c in cells]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

h = np.str_('89283082803ffff')

    def str_to_int(h):
        """
        Converts a hexadecimal string to an H3 64-bit integer index.

        Parameters
        ----------
        h : str
            Hexadecimal string like ``'89754e64993ffff'``

        Returns
        -------
        int
            Unsigned 64-bit integer
        """
        # return _cy.str_to_int(str(h))
>       return _cy.str_to_int(h)
E       TypeError: Argument 'h' has incorrect type (expected str, got numpy.str_)

env/lib/python3.11/site-packages/h3/api/numpy_int/__init__.py:57: TypeError
``` 


* [Test at failing state](https://github.com/uber/h3-py/actions/runs/11194484081/job/31121593037)