### PR TITLE
Allow string subtypes as H3str

### DIFF
--- a/src/h3/_cy/h3lib.pxd
+++ b/src/h3/_cy/h3lib.pxd
@@ -1,7 +1,8 @@
+# cython: c_string_type=unicode, c_string_encoding=utf8
 from cpython cimport bool
 from libc.stdint cimport uint32_t, uint64_t, int64_t
 
-ctypedef basestring H3str
+ctypedef object H3str
 
 cdef extern from 'h3api.h':
     cdef int H3_VERSION_MAJOR

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -53,7 +53,7 @@ def str_to_int(h):
     int
         Unsigned 64-bit integer
     """
-    return _cy.str_to_int(str(h))
+    return _cy.str_to_int(h)
 
 
 def int_to_str(x):

--- a/tests/test_apis/test_basic_str.py
+++ b/tests/test_apis/test_basic_str.py
@@ -22,3 +22,22 @@ def test5():
 
     out = h3.grid_disk('8928308280fffff', 1)
     assert u.same_set(out, expected)
+
+
+def test_string_subtypes():
+
+    class my_str(str):
+        pass
+
+    expected = [
+        '89283082873ffff',
+        '89283082877ffff',
+        '8928308283bffff',
+        '89283082807ffff',
+        '8928308280bffff',
+        '8928308280fffff',
+        '89283082803ffff'
+    ]
+
+    out = h3.grid_disk(my_str('8928308280fffff'), 1)
+    assert u.same_set(out, expected)


### PR DESCRIPTION
A better resolution of #408 using [auto encoding/decoding](https://docs.cython.org/en/stable/src/tutorial/strings.html#auto-encoding-and-decoding).

See #412 for [broken tests](https://github.com/uber/h3-py/actions/runs/11195853327/job/31124011714?pr=412). 