### PR TITLE
Replace codecov with local lcov

### DIFF
--- a/.github/workflows/coverage-lint-pr.yml
+++ b/.github/workflows/coverage-lint-pr.yml
@@ -1,8 +1,8 @@
-name: coverage-lint
+name: pr-coverage-lint
 
 on:
-  push:
-    branches: [master]
+  pull_request:
+    branches: ['*']
 
 jobs:
   tests:
@@ -35,11 +35,11 @@ jobs:
         run: |
           pip install cython
           cythonize tests/test_cython/cython_example.pyx
-          pytest --cov-report=xml
+          pytest --cov-report=lcov
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.3.0
+      - name: Report coverage
+        uses: romeovs/lcov-reporter-action@v0.3.1
         with:
-          file: ./coverage.xml
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          filter-changed-files: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: ./coverage.lcov

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 coverage.xml
+coverage.lcov
 .tox
 nosetests.xml
 .noseids


### PR DESCRIPTION
Potential solution to #393 

The reporting isn't as pretty, and you don't get the full report. But it gets the job done without sending anything outside of the Github Actions instance.

Setup to use local coverage reporting for pull requests, and codecov for push to master. 

Seems like once pushed to master, codecov pulls the proper secrets from `uber/h3-py` (e.g., see [this](https://github.com/uber/h3-py/actions/runs/11195132272) run on `master` vs [this](https://github.com/uber/h3-py/actions/runs/11194900791) failed run on a fork for the PR )

We _could_ just use lcov for everything, but then we'd have to give up the badge on `readme.md`. 