### PR TITLE
Use dynamic versioning to single-source version from git tags

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - uses: actions/setup-python@v5.0.0

--- a/.github/workflows/coverage-lint-pr.yml
+++ b/.github/workflows/coverage-lint-pr.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - uses: actions/setup-python@v5.0.0

--- a/.github/workflows/coverage-lint.yml
+++ b/.github/workflows/coverage-lint.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - uses: actions/setup-python@v5.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - uses: actions/setup-python@v5.0.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -112,6 +112,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - uses: ilammy/msvc-dev-cmd@v1.13.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
         with:
+          # Git-based versioning needs the full history
+          fetch-depth: 0
           submodules: recursive
 
       - name: Setup Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,10 @@ build-backend = 'scikit_build_core.build'
 
 [project]
 name = 'h3'
-version = '4.1.0b3'
 description = "Uber's hierarchical hexagonal geospatial indexing system"
+dynamic = [
+    "version",
+]
 readme = 'readme.md'
 license = {file = 'LICENSE'}
 authors = [
@@ -77,6 +79,7 @@ omit = [
 
 
 [tool.scikit-build]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.exclude = [
     'src/h3lib',
     'docs',
@@ -91,3 +94,5 @@ sdist.include = [
     'src/h3lib/cmake/*',
     'src/h3lib/src/h3lib/*'
 ]
+
+[tool.setuptools_scm]  # Section required


### PR DESCRIPTION
Does this address #383 ? 

Example local install:

```
$ env/bin/python
>>> import h3
>>> h3.__version__
'4.1.0b4.dev0+g6d9a5fc.d20241011'
```

and then with a tag:

```
$ git tag v4.1.0b4
$ env/bin/pip install .
...
$ env/bin/python
>>> import h3; h3.__version__
'4.1.0b4'
```

Currently using the [default versioning scheme](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme); but configurable. 

Wasn't sure what didn't work last time (in #378)