### PR TITLE
`h3shape_to_cells_experimental` takes string containment modes

### DIFF
--- a/.github/workflows/lint_and_coverage.yml
+++ b/.github/workflows/lint_and_coverage.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: Coverage Requirement - Library
         run: |
-          pytest --cov=tests/test_lib --cov-fail-under=100
+          pytest tests/test_lib --cov=h3 --cov=tests/test_lib --cov-fail-under=100
 
       - name: Coverage - Cython
         run: |
           pip install cython
           cythonize tests/test_cython/cython_example.pyx
-          pytest --cov=tests/test_cython
+          pytest tests/test_cython --cov=tests/test_cython

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ avoid adding features or APIs which do not map onto the
 ## Unreleased
 
 - Update to v4.2.0. (#432)
+- Add `h3shape_to_cells_experimental` (#436)
+    - Add `polygon_to_cells_experimental` alias
 
 ## [4.1.2] - 2024-10-26
 

--- a/docs/api_quick.md
+++ b/docs/api_quick.md
@@ -168,6 +168,7 @@ Note that this is reversed from [``__geo_interface__``](https://gist.github.com/
 
 .. autosummary::
    polygon_to_cells
+   polygon_to_cells_experimental
    h3shape_to_cells_experimental
 ```
 

--- a/docs/api_quick.md
+++ b/docs/api_quick.md
@@ -161,6 +161,16 @@ Note that this is reversed from [``__geo_interface__``](https://gist.github.com/
    cells_to_geo
 ```
 
+#### Additional functions
+
+```{eval-rst}
+.. currentmodule:: h3
+
+.. autosummary::
+   polygon_to_cells
+   h3shape_to_cells_experimental
+```
+
 
 ## Specialized functions
 

--- a/makefile
+++ b/makefile
@@ -35,11 +35,11 @@ purge: clear
 	-@rm -rf env
 
 test:
-	./env/bin/pytest --cov=tests/test_lib --cov-fail-under=100
+	./env/bin/pytest tests/test_lib --cov=h3 --cov=tests/test_lib --cov-fail-under=100
 
 	./env/bin/pip install cython
 	./env/bin/cythonize tests/test_cython/cython_example.pyx
-	./env/bin/pytest --cov=tests/test_cython
+	./env/bin/pytest tests/test_cython --cov=tests/test_cython
 
 lint:
 	./env/bin/ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ all = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=h3 --cov-report=term-missing --durations=10"
+addopts = "--cov-report=term-missing --durations=10"
 
 [tool.coverage.run]
 omit = [

--- a/src/h3/_cy/latlng.pyx
+++ b/src/h3/_cy/latlng.pyx
@@ -196,7 +196,7 @@ def polygons_to_cells(polygons, int res):
     return hmm.to_mv()
 
 
-def polygon_to_cells_experimental(outer, int res, int flags, holes=None):
+def polygon_to_cells_experimental(outer, int res, int flag, holes=None):
     """ Get the set of cells whose center is contained in a polygon.
 
     The polygon is defined similarity to the GeoJson standard, with an exterior
@@ -221,8 +221,8 @@ def polygon_to_cells_experimental(outer, int res, int flags, holes=None):
         A ring given by a sequence of lat/lng pairs.
     res : int
         The resolution of the output hexagons
-    flags : int
-        Polygon to cells flags, such as containment mode.
+    flag : int
+        Polygon to cells flag, such as containment mode.
     holes : list or tuple
         A collection of rings, each given by a sequence of lat/lng pairs.
         These describe any the "holes" in the polygon.
@@ -238,21 +238,21 @@ def polygon_to_cells_experimental(outer, int res, int flags, holes=None):
     gp = GeoPolygon(outer, holes=holes)
 
     check_for_error(
-        h3lib.maxPolygonToCellsSizeExperimental(&gp.gp, res, flags, &n)
+        h3lib.maxPolygonToCellsSizeExperimental(&gp.gp, res, flag, &n)
     )
 
     hmm = H3MemoryManager(n)
     check_for_error(
-        h3lib.polygonToCellsExperimental(&gp.gp, res, flags, n, hmm.ptr)
+        h3lib.polygonToCellsExperimental(&gp.gp, res, flag, n, hmm.ptr)
     )
     mv = hmm.to_mv()
 
     return mv
 
 
-def polygons_to_cells_experimental(polygons, int res, int flags):
+def polygons_to_cells_experimental(polygons, int res, int flag):
     mvs = [
-        polygon_to_cells_experimental(outer=poly.outer, res=res, holes=poly.holes, flags=flags)
+        polygon_to_cells_experimental(outer=poly.outer, res=res, holes=poly.holes, flag=flag)
         for poly in polygons
     ]
 

--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -2,16 +2,6 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum
 
 
-class ContainmentMode(int, Enum):
-    """
-    Containment modes for use with ``polygon_to_cells_experimental``.
-    """
-    containment_center = 0
-    containment_full = 1
-    containment_overlapping = 2
-    containment_overlapping_bbox = 3
-
-
 class H3Shape(metaclass=ABCMeta):
     """
     Abstract parent class of ``LatLngPoly`` and ``LatLngMultiPoly``.

--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from enum import Enum
 
 
 class H3Shape(metaclass=ABCMeta):

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -467,6 +467,12 @@ def uncompact_cells(cells, res):
 
     return _out_collection(hu)
 
+def polygon_to_cells(h3shape, res):
+    """
+    Alias for ``h3shape_to_cells``.
+    """
+    return h3shape_to_cells(h3shape, res)
+
 
 def h3shape_to_cells(h3shape, res):
     """
@@ -519,11 +525,15 @@ def h3shape_to_cells(h3shape, res):
     return _out_collection(mv)
 
 
-def polygon_to_cells(h3shape, res):
+def polygon_to_cells_experimental(
+    h3shape: H3Shape,
+    res: int,
+    contain: Literal['center', 'full', 'overlap', 'bbox_overlap'] = 'center',
+):
     """
-    Alias for ``h3shape_to_cells``.
+    Alias for ``h3shape_to_cells_experimental``.
     """
-    return h3shape_to_cells(h3shape, res)
+    return h3shape_to_cells_experimental(h3shape, res, contain)
 
 
 def h3shape_to_cells_experimental(

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -525,12 +525,12 @@ def polygon_to_cells(h3shape, res):
     return h3shape_to_cells(h3shape, res)
 
 
-def h3shape_to_cells_experimental(h3shape, res, containment='center'):
+def h3shape_to_cells_experimental(h3shape, res, contain='center'):
     """
     Experimental function similar to ``h3shape_to_cells``, but with support for
     multiple cell containment modes.
 
-    Using ``containment='center'`` should give identical behavior as
+    Using ``contain='center'`` should give identical behavior as
     ``h3shape_to_cells``.
 
     Note that this function is **experimental** and has no API stability gaurantees
@@ -542,7 +542,7 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     h3shape : ``H3Shape``
     res : int
         Resolution of the output cells
-    containment : {'center', 'full', 'overlap', 'bbox_overlap'}
+    contain : {'center', 'full', 'overlap', 'bbox_overlap'}
         Specifies the containment condition.
             - 'center': Cell center is contained in shape
             - 'full': Cell is fully contained in shape
@@ -574,14 +574,14 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     There is currently no guaranteed order of the output cells.
     """
 
-    containment_modes = {
+    contain_modes = {
         'center': 0,
         'full': 1,
         'overlap': 2,
         'bbox_overlap': 3,
     }
 
-    flag = containment_modes[containment]
+    flag = contain_modes[contain]
 
     # todo: not sure if i want this dispatch logic here. maybe in the objects?
     if isinstance(h3shape, LatLngPoly):

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -525,11 +525,13 @@ def polygon_to_cells(h3shape, res):
     return h3shape_to_cells(h3shape, res)
 
 
-# TODO: better docstring explaining experimental options
 def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     """
-    Return the collection of H3 cells at a given resolution whose center points
-    are contained within an ``LatLngPoly`` or ``LatLngMultiPoly``.
+    Experimental function similar to ``h3shape_to_cells``, but with support for
+    multiple cell containment modes.
+
+    Using ``containment='center'`` should give identical behavior as
+    ``h3shape_to_cells``.
 
     Parameters
     ----------
@@ -542,7 +544,6 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
             - 'full': Cell is fully contained in shape
             - 'overlap': Cell is partially contained in shape
             - 'bbox_overlap': Cell bounding box is partially contained in shape
-
 
     Returns
     -------

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -533,6 +533,10 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     Using ``containment='center'`` should give identical behavior as
     ``h3shape_to_cells``.
 
+    Note that this function is **experimental** and has no API stability gaurantees
+    across versions, so it may change in the future.
+
+
     Parameters
     ----------
     h3shape : ``H3Shape``

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -1,4 +1,5 @@
 # This file is **symlinked** across the APIs to ensure they are exactly the same.
+from typing import Literal
 
 from ... import _cy
 from ..._h3shape import (
@@ -525,7 +526,11 @@ def polygon_to_cells(h3shape, res):
     return h3shape_to_cells(h3shape, res)
 
 
-def h3shape_to_cells_experimental(h3shape, res, contain='center'):
+def h3shape_to_cells_experimental(
+    h3shape: H3Shape,
+    res: int,
+    contain: Literal['center', 'full', 'overlap', 'bbox_overlap'] = 'center',
+):
     """
     Experimental function similar to ``h3shape_to_cells``, but with support for
     multiple cell containment modes.
@@ -542,12 +547,14 @@ def h3shape_to_cells_experimental(h3shape, res, contain='center'):
     h3shape : ``H3Shape``
     res : int
         Resolution of the output cells
-    contain : {'center', 'full', 'overlap', 'bbox_overlap'}
+    contain : {'center', 'full', 'overlap', 'bbox_overlap'}, optional
         Specifies the containment condition.
             - 'center': Cell center is contained in shape
             - 'full': Cell is fully contained in shape
             - 'overlap': Cell is partially contained in shape
             - 'bbox_overlap': Cell bounding box is partially contained in shape
+
+        Default is 'center'.
 
     Returns
     -------

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -535,8 +535,13 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     h3shape : ``H3Shape``
     res : int
         Resolution of the output cells
-    containment: str
-        'center', 'full', 'overlap', 'bbox_overlap'
+    containment : {'center', 'full', 'overlap', 'bbox_overlap'}
+        Specifies the containment condition.
+            - 'center': Cell center is contained in shape
+            - 'full': Cell is fully contained in shape
+            - 'overlap': Cell is partially contained in shape
+            - 'bbox_overlap': Cell bounding box is partially contained in shape
+
 
     Returns
     -------

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -525,6 +525,7 @@ def polygon_to_cells(h3shape, res):
     return h3shape_to_cells(h3shape, res)
 
 
+# TODO: better docstring explaining experimental options
 def h3shape_to_cells_experimental(h3shape, res, containment='center'):
     """
     Return the collection of H3 cells at a given resolution whose center points
@@ -595,13 +596,6 @@ def h3shape_to_cells_experimental(h3shape, res, containment='center'):
         raise ValueError('Unrecognized type: ' + str(type(h3shape)))
 
     return _out_collection(mv)
-
-
-def polygon_to_cells_experimental(h3shape, res, containment='center'):
-    """
-    Alias for ``h3shape_to_cells_experimental``.
-    """
-    return h3shape_to_cells_experimental(h3shape, res, containment=containment)
 
 
 def cells_to_h3shape(cells, *, tight=True):

--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -467,6 +467,7 @@ def uncompact_cells(cells, res):
 
     return _out_collection(hu)
 
+
 def polygon_to_cells(h3shape, res):
     """
     Alias for ``h3shape_to_cells``.

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -119,9 +119,9 @@ def test_polygon_to_cells():
 
 def test_polygon_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in [0, 'containment_center', h3.ContainmentMode.containment_center]:
+    for flags in ['center']:
         # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, flags=flags)
+        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1253
         assert '89283080527ffff' in out
@@ -130,9 +130,9 @@ def test_polygon_to_cells_experimental():
 
 def test_polygon_to_cells_experimental_full():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in [1, 'containment_full', h3.ContainmentMode.containment_full]:
+    for flags in ['full']:
         # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, flags=flags)
+        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1175
         assert '89283082a1bffff' in out
@@ -142,13 +142,9 @@ def test_polygon_to_cells_experimental_full():
 
 def test_polygon_to_cells_experimental_overlapping():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in [
-        2,
-        'containment_overlapping',
-        h3.ContainmentMode.containment_overlapping
-    ]:
+    for flags in ['overlap']:
         # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, flags=flags)
+        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1334
         assert '89283080527ffff' in out
@@ -158,12 +154,10 @@ def test_polygon_to_cells_experimental_overlapping():
 def test_polygon_to_cells_experimental_overlapping_bbox():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in [
-        3,
-        'containment_overlapping_bbox',
-        h3.ContainmentMode.containment_overlapping_bbox
+        'bbox_overlap'
     ]:
         # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, flags=flags)
+        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1416
         assert '89283080527ffff' in out
@@ -172,10 +166,10 @@ def test_polygon_to_cells_experimental_overlapping_bbox():
 
 def test_polygon_to_cells_experimental_invalid_mode():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in [1.0, 'containment_overlapping_bbox_abc', None]:
-        with pytest.raises(ValueError):
+    for flags in ['containment_overlapping_bbox_abc']:
+        with pytest.raises(KeyError):
             # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-            h3.polygon_to_cells_experimental(poly, res=9, flags=flags)
+            h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
 
 
 def test_poly_to_cells_experimental_mpoly():
@@ -187,7 +181,7 @@ def test_poly_to_cells_experimental_mpoly():
     assert (
         set(h3.polygon_to_cells_experimental(mpoly, res=9))
         ==
-        set(h3.polygon_to_cells_experimental(mpoly, res=9, flags='containment_center'))
+        set(h3.polygon_to_cells_experimental(mpoly, res=9, containment='center'))
     )
 
     assert (
@@ -196,14 +190,14 @@ def test_poly_to_cells_experimental_mpoly():
         set(h3.polygon_to_cells_experimental(
             mpoly,
             res=9,
-            flags='containment_overlapping'
+            containment='overlap'
         ))
     )
 
     assert 120 == len(h3.polygon_to_cells_experimental(
         mpoly,
-        res=9,
-        flags='containment_overlapping'
+        res = 9,
+        containment = 'overlap'
     ))
 
 

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -119,7 +119,8 @@ def test_polygon_to_cells():
 
 def test_polygon_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
-    # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
+    # Note that `polygon_to_cells_experimental` is an alias for
+    # `h3shape_to_cells_experimental`
     out = h3.polygon_to_cells_experimental(poly, res=9, contain='center')
 
     assert len(out) == 1253

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -117,6 +117,16 @@ def test_polygon_to_cells():
     assert '89283095edbffff' in out
 
 
+def test_polygon_to_cells_experimental():
+    poly = h3.LatLngPoly(sf_7x7)
+    # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
+    out = h3.polygon_to_cells_experimental(poly, res=9, contain='center')
+
+    assert len(out) == 1253
+    assert '89283080527ffff' in out
+    assert '89283095edbffff' in out
+
+
 def test_h3shape_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
 

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -117,22 +117,20 @@ def test_polygon_to_cells():
     assert '89283095edbffff' in out
 
 
-def test_polygon_to_cells_experimental():
+def test_h3shape_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in ['center']:
-        # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
+        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1253
         assert '89283080527ffff' in out
         assert '89283095edbffff' in out
 
 
-def test_polygon_to_cells_experimental_full():
+def test_h3shape_to_cells_experimental_full():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in ['full']:
-        # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
+        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1175
         assert '89283082a1bffff' in out
@@ -140,36 +138,34 @@ def test_polygon_to_cells_experimental_full():
         assert '89283095edbffff' in out
 
 
-def test_polygon_to_cells_experimental_overlapping():
+def test_h3shape_to_cells_experimental_overlapping():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in ['overlap']:
-        # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
+        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1334
         assert '89283080527ffff' in out
         assert '89283095edbffff' in out
 
 
-def test_polygon_to_cells_experimental_overlapping_bbox():
+# TODO: fix these for flags loops
+def test_h3shape_to_cells_experimental_overlapping_bbox():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in [
         'bbox_overlap'
     ]:
-        # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-        out = h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
+        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
         assert len(out) == 1416
         assert '89283080527ffff' in out
         assert '89283095edbffff' in out
 
 
-def test_polygon_to_cells_experimental_invalid_mode():
+def test_h3shape_to_cells_experimental_invalid_mode():
     poly = h3.LatLngPoly(sf_7x7)
     for flags in ['containment_overlapping_bbox_abc']:
         with pytest.raises(KeyError):
-            # Note that `polygon_to_cells` is an alias for `h3shape_to_cells`
-            h3.polygon_to_cells_experimental(poly, res=9, containment=flags)
+            h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
 
 def test_poly_to_cells_experimental_mpoly():
@@ -179,22 +175,22 @@ def test_poly_to_cells_experimental_mpoly():
     )
 
     assert (
-        set(h3.polygon_to_cells_experimental(mpoly, res=9))
+        set(h3.h3shape_to_cells_experimental(mpoly, res=9))
         ==
-        set(h3.polygon_to_cells_experimental(mpoly, res=9, containment='center'))
+        set(h3.h3shape_to_cells_experimental(mpoly, res=9, containment='center'))
     )
 
     assert (
-        set(h3.polygon_to_cells_experimental(mpoly, res=9))
+        set(h3.h3shape_to_cells_experimental(mpoly, res=9))
         <
-        set(h3.polygon_to_cells_experimental(
+        set(h3.h3shape_to_cells_experimental(
             mpoly,
             res=9,
             containment='overlap'
         ))
     )
 
-    assert 120 == len(h3.polygon_to_cells_experimental(
+    assert 120 == len(h3.h3shape_to_cells_experimental(
         mpoly,
         res = 9,
         containment = 'overlap'

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -119,53 +119,52 @@ def test_polygon_to_cells():
 
 def test_h3shape_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in ['center']:
-        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
-        assert len(out) == 1253
-        assert '89283080527ffff' in out
-        assert '89283095edbffff' in out
+    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='center')
+
+    assert len(out) == 1253
+    assert '89283080527ffff' in out
+    assert '89283095edbffff' in out
 
 
 def test_h3shape_to_cells_experimental_full():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in ['full']:
-        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
-        assert len(out) == 1175
-        assert '89283082a1bffff' in out
-        assert '89283080527ffff' not in out
-        assert '89283095edbffff' in out
+    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='full')
+
+    assert len(out) == 1175
+    assert '89283082a1bffff' in out
+    assert '89283080527ffff' not in out
+    assert '89283095edbffff' in out
 
 
 def test_h3shape_to_cells_experimental_overlapping():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in ['overlap']:
-        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
 
-        assert len(out) == 1334
-        assert '89283080527ffff' in out
-        assert '89283095edbffff' in out
+    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='overlap')
+
+    assert len(out) == 1334
+    assert '89283080527ffff' in out
+    assert '89283095edbffff' in out
 
 
-# TODO: fix these for flags loops
 def test_h3shape_to_cells_experimental_overlapping_bbox():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in [
-        'bbox_overlap'
-    ]:
-        out = h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
+    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='bbox_overlap')
 
-        assert len(out) == 1416
-        assert '89283080527ffff' in out
-        assert '89283095edbffff' in out
+    assert len(out) == 1416
+    assert '89283080527ffff' in out
+    assert '89283095edbffff' in out
 
 
 def test_h3shape_to_cells_experimental_invalid_mode():
     poly = h3.LatLngPoly(sf_7x7)
-    for flags in ['containment_overlapping_bbox_abc']:
-        with pytest.raises(KeyError):
-            h3.h3shape_to_cells_experimental(poly, res=9, containment=flags)
+    with pytest.raises(KeyError):
+        h3.h3shape_to_cells_experimental(
+            poly,
+            res = 9,
+            containment = 'containment_overlapping_bbox_abc',
+        )
 
 
 def test_poly_to_cells_experimental_mpoly():
@@ -185,8 +184,8 @@ def test_poly_to_cells_experimental_mpoly():
         <
         set(h3.h3shape_to_cells_experimental(
             mpoly,
-            res=9,
-            containment='overlap'
+            res = 9,
+            containment = 'overlap'
         ))
     )
 

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -120,7 +120,7 @@ def test_polygon_to_cells():
 def test_h3shape_to_cells_experimental():
     poly = h3.LatLngPoly(sf_7x7)
 
-    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='center')
+    out = h3.h3shape_to_cells_experimental(poly, res=9, contain='center')
 
     assert len(out) == 1253
     assert '89283080527ffff' in out
@@ -130,7 +130,7 @@ def test_h3shape_to_cells_experimental():
 def test_h3shape_to_cells_experimental_full():
     poly = h3.LatLngPoly(sf_7x7)
 
-    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='full')
+    out = h3.h3shape_to_cells_experimental(poly, res=9, contain='full')
 
     assert len(out) == 1175
     assert '89283082a1bffff' in out
@@ -141,7 +141,7 @@ def test_h3shape_to_cells_experimental_full():
 def test_h3shape_to_cells_experimental_overlapping():
     poly = h3.LatLngPoly(sf_7x7)
 
-    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='overlap')
+    out = h3.h3shape_to_cells_experimental(poly, res=9, contain='overlap')
 
     assert len(out) == 1334
     assert '89283080527ffff' in out
@@ -150,7 +150,7 @@ def test_h3shape_to_cells_experimental_overlapping():
 
 def test_h3shape_to_cells_experimental_overlapping_bbox():
     poly = h3.LatLngPoly(sf_7x7)
-    out = h3.h3shape_to_cells_experimental(poly, res=9, containment='bbox_overlap')
+    out = h3.h3shape_to_cells_experimental(poly, res=9, contain='bbox_overlap')
 
     assert len(out) == 1416
     assert '89283080527ffff' in out
@@ -163,7 +163,7 @@ def test_h3shape_to_cells_experimental_invalid_mode():
         h3.h3shape_to_cells_experimental(
             poly,
             res = 9,
-            containment = 'containment_overlapping_bbox_abc',
+            contain = 'contain_overlapping_bbox_abc',
         )
 
 
@@ -176,7 +176,7 @@ def test_poly_to_cells_experimental_mpoly():
     assert (
         set(h3.h3shape_to_cells_experimental(mpoly, res=9))
         ==
-        set(h3.h3shape_to_cells_experimental(mpoly, res=9, containment='center'))
+        set(h3.h3shape_to_cells_experimental(mpoly, res=9, contain='center'))
     )
 
     assert (
@@ -185,14 +185,14 @@ def test_poly_to_cells_experimental_mpoly():
         set(h3.h3shape_to_cells_experimental(
             mpoly,
             res = 9,
-            containment = 'overlap'
+            contain = 'overlap'
         ))
     )
 
     assert 120 == len(h3.h3shape_to_cells_experimental(
         mpoly,
         res = 9,
-        containment = 'overlap'
+        contain = 'overlap'
     ))
 
 


### PR DESCRIPTION
- Just use string containment modes for `h3shape_to_cells_experimental`
- Add `polygon_to_cells` and `h3shape_to_cells_experimental` and `polygon_to_cells_experimental` to docs
- Avoid repeating tests when checking coverage