### PR TITLE
Prep for v4.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
-- Update to v4.2.0. (#432)
+None.
+
+## [4.2.0] - 2025-01-26
+
+- Update h3lib to v4.2.0. (#432)
 - Add `h3shape_to_cells_experimental` (#436)
     - Add `polygon_to_cells_experimental` alias
 

--- a/dev_notes.md
+++ b/dev_notes.md
@@ -49,6 +49,7 @@ git submodule update --init
 
 - update `CHANGELOG.md` to reflect any changes since the last release
 - update the `h3-py` version in `pyproject.toml`
+- if updating the C `h3lib` version, update the version badge on the readme
 - create PR, get reviews, and merge with these changes
 - go to https://github.com/uber/h3-py/releases and "Draft a new release"
     - set the tag version and the release to the version. e.g., `v3.7.2`

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/h3.svg)](https://badge.fury.io/py/h3)
 [![PyPI downloads](https://img.shields.io/pypi/dm/h3.svg)](https://pypistats.org/packages/h3)
 [![conda](https://img.shields.io/conda/vn/conda-forge/h3-py.svg)](https://anaconda.org/conda-forge/h3-py)
-[![version](https://img.shields.io/badge/h3-v4.1.0-blue.svg)](https://github.com/uber/h3/releases/tag/v4.1.0)
+[![version](https://img.shields.io/badge/h3-v4.2.0-blue.svg)](https://github.com/uber/h3/releases/tag/v4.2.0)
 [![version](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/uber/h3-py/blob/master/LICENSE)
 
 [![Tests](https://github.com/uber/h3-py/workflows/tests/badge.svg)](https://github.com/uber/h3-py/actions)


### PR DESCRIPTION
## [4.2.0] - 2025-01-26

- Update h3lib to v4.2.0. (#432)
- Add `h3shape_to_cells_experimental` (#436)
    - Add `polygon_to_cells_experimental` alias