### PR TITLE
Prep for v4.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ avoid adding features or APIs which do not map onto the
 
 None.
 
+## [4.2.1] - 2025-01-31
+
+- Correct pyproject.toml links for PyPI (#441)
+- Update coverage badge (#443)
+
 ## [4.2.0] - 2025-01-26
 
 - Update h3lib to v4.2.0. (#432)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'scikit_build_core.build'
 
 [project]
 name = 'h3'
-version = '4.2.0'
+version = '4.2.1'
 description = "Uber's hierarchical hexagonal geospatial indexing system"
 readme = 'readme.md'
 license = {file = 'LICENSE'}


### PR DESCRIPTION
## [4.2.1] - 2025-01-31

- Correct pyproject.toml links for PyPI (#441)
- Update coverage badge (#443)