### PR TITLE
update for h3 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
-None.
+- Update h3lib to v4.3.0. (#)
 
 ## [4.2.2] - 2025-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
-- Update h3lib to v4.3.0. (#)
+- Update h3lib to v4.3.0. (#461)
 
 ## [4.2.2] - 2025-03-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'scikit_build_core.build'
 
 [project]
 name = 'h3'
-version = '4.2.2'
+version = '4.3.0'
 description = "Uber's hierarchical hexagonal geospatial indexing system"
 readme = 'readme.md'
 license = {file = 'LICENSE'}

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/h3.svg)](https://badge.fury.io/py/h3)
 [![PyPI downloads](https://img.shields.io/pypi/dm/h3.svg)](https://pypistats.org/packages/h3)
 [![conda](https://img.shields.io/conda/vn/conda-forge/h3-py.svg)](https://anaconda.org/conda-forge/h3-py)
-[![version](https://img.shields.io/badge/h3-v4.2.1-blue.svg)](https://github.com/uber/h3/releases/tag/v4.2.1)
+[![version](https://img.shields.io/badge/h3-v4.3.0-blue.svg)](https://github.com/uber/h3/releases/tag/v4.3.0)
 [![version](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/uber/h3-py/blob/master/LICENSE)
 
 [![Tests](https://github.com/uber/h3-py/workflows/tests/badge.svg)](https://github.com/uber/h3-py/actions)

--- a/src/h3/_cy/h3lib.pxd
+++ b/src/h3/_cy/h3lib.pxd
@@ -139,6 +139,7 @@ cdef extern from 'h3api.h':
     H3Error localIjToCell(H3int origin, const CoordIJ *ij, uint32_t mode, H3int *out) nogil
 
     H3Error gridDiskDistances(H3int origin, int k, H3int *out, int *distances) nogil
+    H3Error gridRing(H3int origin, int k, H3int *out) nogil
     H3Error gridRingUnsafe(H3int origin, int k, H3int *out) nogil
 
     H3Error areNeighborCells(H3int origin, H3int destination, int *out) nogil


### PR DESCRIPTION
## v4.3.0
- Update `h3-py` and `h3lib` to v4.3.0. (#461, https://github.com/uber/h3/pull/1016)

Uses `gridRing` in C library, introduced in https://github.com/uber/h3/pull/1016, instead of handling fallback logic in Cython when encountering pentagon distortion.