### PR TITLE
Add support for building h3-py wheel on WoA

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,6 +71,19 @@ jobs:
             build: 'cp3*-win_amd64'
             name: Windows 64-bit
 
+          - os: windows-11-arm 
+            build: 'cp310-win_arm64'
+            name: Windows ARM64 3.10
+          - os: windows-11-arm
+            build: 'cp311-win_arm64'
+            name: Windows ARM64 3.11
+          - os: windows-11-arm
+            build: 'cp312-win_arm64'
+            name: Windows ARM64 3.12
+          - os: windows-11-arm
+            build: 'cp313-win_arm64'
+            name: Windows ARM64 3.13
+
           - os: ubuntu-22.04
             build: 'cp*-manylinux_x86_64'
             name: Linux Intel glibc 64-bit
@@ -118,8 +131,17 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: ilammy/msvc-dev-cmd@v1.13.0
-        if: runner.os == 'Windows'
+      - name: Set MSVC for Windows-x64  
+        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+        if: matrix.os == 'windows-latest'
+        with:
+          architecture: x64
+          
+      - name: Set MSVC for Windows-ARM64
+        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+        if: matrix.os == 'windows-11-arm'
+        with:
+          architecture: arm64
 
       - name: Set Windows variables
         if: runner.os == 'Windows'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -71,9 +71,6 @@ jobs:
             build: 'cp3*-win_amd64'
             name: Windows 64-bit
 
-          - os: windows-11-arm 
-            build: 'cp310-win_arm64'
-            name: Windows ARM64 3.10
           - os: windows-11-arm
             build: 'cp311-win_arm64'
             name: Windows ARM64 3.11
@@ -132,16 +129,16 @@ jobs:
           submodules: recursive
 
       - name: Set MSVC for Windows-x64  
-        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+        uses: microsoft/setup-msbuild@v2
         if: matrix.os == 'windows-latest'
         with:
-          architecture: x64
-          
+          msbuild-architecture: x64
+
       - name: Set MSVC for Windows-ARM64
-        uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
+        uses: microsoft/setup-msbuild@v2
         if: matrix.os == 'windows-11-arm'
         with:
-          architecture: arm64
+          msbuild-architecture: arm64
 
       - name: Set Windows variables
         if: runner.os == 'Windows'
@@ -156,7 +153,7 @@ jobs:
         with:
           platforms: aarch64
 
-      - uses: pypa/cibuildwheel@v2.21.3
+      - uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_TEST_REQUIRES: pytest pytest-cov numpy
           CIBW_TEST_COMMAND: pytest {project}/tests


### PR DESCRIPTION
Description:

Closes: https://github.com/uber/h3-py/issues/455

- The PR introduces CI setup for building h3-py wheels for Windows on ARM.
- The changes include adding support for new Window on ARM github runners and adding new MSVC composite action for both x64 and arm64 based on the runner.
- I could see there is an existing PR for this support, but it seems like blocked due to several build errors  - This PR builds h3-py wheel without any issues for WoA.