### PR TITLE
Avoid building duplicate wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -60,9 +60,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-14
-            build: 'cp*-macosx_arm64'
-            name: macOS14
           - os: macos-15
             build: 'cp*-macosx_arm64'
             name: macOS15


### PR DESCRIPTION
We were getting the following error when checking the wheels before uploading to PyPI: https://github.com/uber/h3-py/actions/runs/20215109025/job/58048009774:

```
Traceback (most recent call last):
  File "/root/.local/bin/twine", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/root/.local/lib/python3.13/site-packages/twine/__main__.py", line 33, in main
    error = cli.dispatch(sys.argv[1:])
  File "/root/.local/lib/python3.13/site-packages/twine/cli.py", line 139, in dispatch
    return main(args.args)
  File "/root/.local/lib/python3.13/site-packages/twine/commands/check.py", line 195, in main
    return check(parsed_args.dists, strict=parsed_args.strict)
  File "/root/.local/lib/python3.13/site-packages/twine/commands/check.py", line 141, in check
    warnings, is_ok = _check_file(filename, render_warning_stream)
                      ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.13/site-packages/twine/commands/check.py", line 84, in _check_file
    package = package_file.PackageFile.from_filename(filename, comment=None)
  File "/root/.local/lib/python3.13/site-packages/twine/package.py", line 202, in from_filename
    data = dist.read()
  File "/root/.local/lib/python3.13/site-packages/twine/wheel.py", line 71, in read
    data = read_file(candidate)
  File "/root/.local/lib/python3.13/site-packages/twine/wheel.py", line 60, in read_file
    return archive.read(name)
           ~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/zipfile/__init__.py", line 1602, in read
    with self.open(name, "r", pwd) as fp:
         ~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/zipfile/__init__.py", line 1660, in open
    raise BadZipFile("Bad magic number for file header")
zipfile.BadZipFile: Bad magic number for file header
Checking dist/h3-4.4.0-cp311-cp311-macosx_11_0_arm64.whl: 
```

I was initially confused, because we check with Twine earlier in the action, so I didn't understand why that was passing, but this later check with Twine was failing. It turns out, that macos 14 and 15 build exactly the same wheels, so the checks pass independently, but we then combine all the wheels into a single tarball, which is corrupted because we compress two copies of the mac wheels with exactly the same filename. (Or, at least, that's my guess of what's going on.)

This PR drops macos 14 from generating wheels, which should fix the issue. 

**update**: Added a twine check after forming the tarball, which should catch this issue earlier than during release. Checked that we get the expected failure below.