### PR TITLE
Prep for v4.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
+## [4.4.2] - 2026-01-29
+
+- Check for error from `cellsToLinkedMultiPolygon` (#477)
+
 ## [4.4.1] - 2025-12-15
 
 - Fix PyPI publishing issue (#474)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'scikit_build_core.build'
 
 [project]
 name = 'h3'
-version = '4.4.1'
+version = '4.4.2'
 description = "Uber's hierarchical hexagonal geospatial indexing system"
 readme = 'readme.md'
 license = {file = 'LICENSE'}


### PR DESCRIPTION
## [4.4.2] - 2026-01-29

- Check for error from `cellsToLinkedMultiPolygon` (#477)