### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v6.0.0
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: 3.11
 
@@ -31,7 +31,7 @@ jobs:
         run: jupyter-book build docs/ --warningiserror --keep-going --all
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: html
           path: docs/_build/html

--- a/.github/workflows/lint_and_coverage.yml
+++ b/.github/workflows/lint_and_coverage.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v6.0.0
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: 3.11
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,11 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v6.0.0
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: '${{ matrix.python-version }}'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: 3.11
 
@@ -48,7 +48,7 @@ jobs:
         run: pytest
 
       - name: Upload artifacts to GitHub
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: temp_result_sdist
           path: ./dist
@@ -130,7 +130,7 @@ jobs:
             name: Linux Aarch64 3.14
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -171,7 +171,7 @@ jobs:
           pipx run twine check wheelhouse/*
 
       - name: Upload artifacts to GitHub
-        uses: actions/upload-artifact@v5.0.0
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: temp_result_${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download merged artifacts
-        uses: actions/download-artifact@v6.0.0
+        uses: actions/download-artifact@v7.0.0
         with:
           name: wheels_and_sdist
           path: dist
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v6.0.0
+      - uses: actions/download-artifact@v7.0.0
         with:
           name: wheels_and_sdist
           path: dist


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v5.0.0`](https://github.com/actions/checkout/releases/tag/v5.0.0) | [`v6.0.2`](https://github.com/actions/checkout/releases/tag/v6.0.2) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build_docs.yml, lint_and_coverage.yml, tests.yml, wheels.yml |
| `actions/download-artifact` | [`v6.0.0`](https://github.com/actions/download-artifact/releases/tag/v6.0.0) | [`v7.0.0`](https://github.com/actions/download-artifact/releases/tag/v7.0.0) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | wheels.yml |
| `actions/setup-python` | [`v6.0.0`](https://github.com/actions/setup-python/releases/tag/v6.0.0) | [`v6.2.0`](https://github.com/actions/setup-python/releases/tag/v6.2.0) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | build_docs.yml, lint_and_coverage.yml, tests.yml, wheels.yml |
| `actions/upload-artifact` | [`v5.0.0`](https://github.com/actions/upload-artifact/releases/tag/v5.0.0) | [`v6.0.0`](https://github.com/actions/upload-artifact/releases/tag/v6.0.0) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build_docs.yml, wheels.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
