### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -155,11 +155,11 @@ jobs:
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@v3.7.0
         with:
           platforms: aarch64
 
-      - uses: pypa/cibuildwheel@v3.2.1
+      - uses: pypa/cibuildwheel@v3.3.1
         env:
           CIBW_TEST_REQUIRES: pytest pytest-cov numpy
           CIBW_TEST_COMMAND: pytest {project}/tests
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v5.0.0
+        uses: actions/upload-artifact/merge@v6
         with:
           name: wheels_and_sdist
           pattern: temp_result_*


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-artifact/merge` | [`v5.0.0`](https://github.com/actions/upload-artifact/merge/releases/tag/v5.0.0) | [`v6`](https://github.com/actions/upload-artifact/merge/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/merge/releases/tag/v6) | wheels.yml |
| `docker/setup-qemu-action` | [`v3.6.0`](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0) | [`v3.7.0`](https://github.com/docker/setup-qemu-action/releases/tag/v3.7.0) | [Release](https://github.com/docker/setup-qemu-action/releases/tag/v3) | wheels.yml |
| `pypa/cibuildwheel` | [`v3.2.1`](https://github.com/pypa/cibuildwheel/releases/tag/v3.2.1) | [`v3.3.1`](https://github.com/pypa/cibuildwheel/releases/tag/v3.3.1) | [Release](https://github.com/pypa/cibuildwheel/releases/tag/v3) | wheels.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
