### PR TITLE
Typofix: Make docstring reflect what the actually function does

### DIFF
--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -160,7 +160,7 @@ def is_valid_cell(h):
 
 def is_valid_directed_edge(edge):
     """
-    Validates an H3 unidirectional edge.
+    Validates an H3 directed edge.
 
     Returns
     -------


### PR DESCRIPTION
There is the [`is_valid_directed_edge`](https://github.com/uber/h3-py/blob/adba976e22a65a5b1ae29eabe8782ff5922f843b/src/h3/api/basic_int/__init__.py#L161) function, which validates a directed edge. Now the docstring agrees.

The previous description ("Validates an H3 _unidirectional_ edge") seems to have been written for the new removed `h3_unidirectional_edge_is_valid` function. When that function was removed [here](https://github.com/uber/h3-py/pull/250/changes#diff-9368e938da0044df4c0a4b85f0d91c3d8be718b1258a2367ec88967580171842R169), it's description survived:

<img width="1708" height="396" alt="Screenshot 2026-03-26 at 20 51 03" src="https://github.com/user-attachments/assets/8e1a59bc-e5f1-4714-9766-99a1f2eee412" />

I am new here, and I really like this project.