### PR TITLE
ci: declare contents:read on lint_and_coverage workflow

### DIFF
--- a/.github/workflows/lint_and_coverage.yml
+++ b/.github/workflows/lint_and_coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     name: Lint and Coverage


### PR DESCRIPTION
Pins `.github/workflows/lint_and_coverage.yml` to `permissions: contents: read` at the workflow level. The job clones, sets up Python, installs deps, runs lint and pytest with coverage. Nothing in that flow calls a GitHub API that needs write access.

The supply-chain motivation behind explicit per-workflow scopes is CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) - a tampered third-party action exfiltrated `GITHUB_TOKEN` via workflow logs, and the blast radius equalled whatever scope the token was issued with. A workflow-level cap of `contents: read` keeps that bounded regardless of what the repo or org default happens to be at any given moment, and survives a future default-widening change. The block also registers with OpenSSF Scorecard's Token-Permissions check, which only credits explicit declarations.

Validated locally with `yaml.safe_load`.
