### PR TITLE
prep for v4.5.0a3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ avoid adding features or APIs which do not map onto the
 
 ## Unreleased
 
+## [4.5.0a3] - 2026-05-22
+
+- Update `h3lib` to v4.5.0 release
+
 ## [4.5.0a2] - 2026-02-27
 
 - `cells_to_h3shape`/`cells_to_geo` now handle all valid cell sets, including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ avoid adding features or APIs which do not map onto the
 
 ## [4.5.0a3] - 2026-05-22
 
-- Update `h3lib` to v4.5.0 release
+- Update `h3lib` to v4.5.0 release (#491)
 
 ## [4.5.0a2] - 2026-02-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'scikit_build_core.build'
 
 [project]
 name = 'h3'
-version = '4.5.0a2'
+version = '4.5.0a3'
 description = "Uber's hierarchical hexagonal geospatial indexing system"
 readme = 'readme.md'
 license = {file = 'LICENSE'}

--- a/src/h3/_cy/h3lib.pxd
+++ b/src/h3/_cy/h3lib.pxd
@@ -156,9 +156,6 @@ cdef extern from 'h3api.h':
     double greatCircleDistanceKm(const LatLng *a, const LatLng *b) nogil
     double greatCircleDistanceM(const LatLng *a, const LatLng *b) nogil
 
-    H3Error cellsToMultiPolygon(const H3int *cells, const int64_t numCells, GeoMultiPolygon *out)
-    void destroyGeoMultiPolygon(GeoMultiPolygon *mpoly)
-
     H3Error maxPolygonToCellsSize(const GeoPolygon *geoPolygon, int res, uint32_t flags, uint64_t *count)
     H3Error polygonToCells(const GeoPolygon *geoPolygon, int res, uint32_t flags, H3int *out)
 
@@ -184,3 +181,11 @@ cdef extern from 'h3api.h':
     # void h3ToString(H3int h, char *str, size_t sz)
 
     # void getH3intesFromUnidirectionalEdge(H3int edge, H3int *originDestination)
+
+
+# cellsToMultiPolygon and destroyGeoMultiPolygon are temporarily excluded
+# from the public API, so we use an internal header until they're moved
+# back into h3api.h
+cdef extern from 'cellsToMultiPoly.h':
+    H3Error cellsToMultiPolygon(const H3int *cells, const int64_t numCells, GeoMultiPolygon *out)
+    void destroyGeoMultiPolygon(GeoMultiPolygon *mpoly)


### PR DESCRIPTION
Bump C lib to v4.5.0.

This change was lighter than I originally expected, assuming we're OK with referencing headers outside of h3api.h. But I think that's fine for h3-py case. 

