### PR TITLE
Fix wheels for python 3.14 free thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ avoid adding features or APIs which do not map onto the
 [H3 core API](https://uber.github.io/h3/#/documentation/api-reference/).
 
 ## Unreleased
+- Fix wheels for Python 3.14.6 free-threading
 
 ## [4.5.0] - 2026-05-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: Free Threading',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: POSIX :: Linux',
     'Operating System :: Microsoft :: Windows',

--- a/src/h3/_cy/cells.pyx
+++ b/src/h3/_cy/cells.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 cimport h3lib
 from .h3lib cimport bool, int64_t, H3int, H3ErrorCodes
 

--- a/src/h3/_cy/edges.pyx
+++ b/src/h3/_cy/edges.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 cimport h3lib
 from .h3lib cimport bool, H3int
 

--- a/src/h3/_cy/error_system.pyx
+++ b/src/h3/_cy/error_system.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 """
 Exceptions from the h3-py library have three possible sources:
 

--- a/src/h3/_cy/latlng.pyx
+++ b/src/h3/_cy/latlng.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 from libc.stdint cimport uint64_t
 
 cimport h3lib

--- a/src/h3/_cy/memory.pyx
+++ b/src/h3/_cy/memory.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 from cython.view cimport array
 from .h3lib cimport H3int
 

--- a/src/h3/_cy/to_multipoly.pyx
+++ b/src/h3/_cy/to_multipoly.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 cimport h3lib
 from h3lib cimport H3int
 from .util cimport check_cell, coord2deg

--- a/src/h3/_cy/util.pyx
+++ b/src/h3/_cy/util.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 from .h3lib cimport (
     H3int,
     H3str,

--- a/src/h3/_cy/vertex.pyx
+++ b/src/h3/_cy/vertex.pyx
@@ -1,3 +1,4 @@
+# cython: freethreading_compatible=True
 cimport h3lib
 from h3lib cimport bool, H3int
 


### PR DESCRIPTION
This PR annotates .pyx cython files to avoid GIL being re-enabled on cpython 3.14 free thread during the execution of packages including h3-py with this python version.

Previously I did run pytest with [pytest-run-parallel](https://github.com/Quansight-Labs/pytest-run-parallel) script and got green, so, for independent parallel process is expected to run without problems. 

Fix #488

Available for questions.