### PR TITLE
Fix: Resolve Android cross-compilation failure (Issue #458)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 
+# --- BEGIN ANDROID CROSS-COMPILATION FIX ---
+# Buildozer/python-for-android uses standard pip install which doesn't natively 
+# pass a CMake toolchain file to scikit-build-core. This detects the Android compiler 
+# from the environment and forces CMake into cross-compilation mode to prevent 
+# it from building host (x86_64) binaries.
+if("$ENV{CC}" MATCHES "android" AND NOT DEFINED CMAKE_SYSTEM_NAME)
+    message(STATUS "Detected Android cross-compilation via environment variables. Setting CMAKE_SYSTEM_NAME=Android")
+    set(CMAKE_SYSTEM_NAME Android)
+endif()
+# --- END ANDROID CROSS-COMPILATION FIX ---
+
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
Fixes #458.

**The Problem:**
When users attempt to compile `h3-py` for Android using Buildozer / `python-for-android`, the build fails at runtime with `ImportError: dlopen failed: ... is for EM_X86_64 (62) instead of EM_AARCH64 (183)`. 
Because `p4a` relies on standard `pip install` without explicitly passing a CMake toolchain file to `scikit-build-core`, CMake defaults to building host binaries (x86_64) instead of respecting the target NDK environment.

**The Solution:**
Added a minimal, non-intrusive environment check in the root `CMakeLists.txt` just before the `project()` declaration. If the standard `$CC` environment variable contains `android` (which is standard behavior for `python-for-android`), it automatically sets `CMAKE_SYSTEM_NAME` to `Android`. 

This forces CMake into cross-compilation mode, allowing it to correctly link against the ARM64 Android NDK without interfering with standard desktop builds (Linux/Mac/Windows).