### PR TITLE
test: clean up string formatting TODO in test_parent_err

### DIFF
--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -131,7 +131,7 @@ def test_parent_err():
     except Exception as e:
         msg = str(e)
 
-    expected = f'Invalid parent resolution -1 for cell 0x{h}.'
+    expected = f'Invalid parent resolution -1 for cell {h}.'
 
     assert msg == expected
 

--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -131,7 +131,7 @@ def test_parent_err():
     except Exception as e:
         msg = str(e)
 
-    expected = f'Invalid parent resolution -1 for cell {h}.'
+    expected = f'Invalid parent resolution -1 for cell 0x{h}.'
 
     assert msg == expected
 

--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -131,9 +131,7 @@ def test_parent_err():
     except Exception as e:
         msg = str(e)
 
-    # todo: revist this weird formatting stuff
-    expected = 'Invalid parent resolution -1 for cell {}.'
-    expected = expected.format(hex(h3.str_to_int(h)))
+    expected = f'Invalid parent resolution -1 for cell 0x{h}.'
 
     assert msg == expected
 


### PR DESCRIPTION
### Description
This is a quick cleanup PR to resolve a lingering `todo` comment I noticed while looking through the test suite. 

In `test_parent_err` inside `tests/test_lib/test_cells_and_edges.py`, there was a comment to revisit the "weird formatting stuff" used to generate the hex error message. I replaced the clunky `hex(h3.str_to_int(h))` conversion with a standard, readable Python f-string: `f'Invalid parent resolution -1 for cell 0x{h}.'`

This makes the test much more idiomatic and removes the TODO without changing any of the underlying test logic.

### Maintainers
cc: @dfellis @ajfriend @isaacbrodsky - Just a small housekeeping fix for whenever you have the time to review!