### PR TITLE
test: add test for uncompacting to a coarser resolution

### DIFF
--- a/src/h3/api/basic_int/__init__.py
+++ b/src/h3/api/basic_int/__init__.py
@@ -474,8 +474,6 @@ def uncompact_cells(cells, res):
     -----
     There is currently no guaranteed order of the output cells.
     """
-    # TODO: add test to make sure an error is returned when input contains cell
-    # smaller than output res.
 
     hc = _in_collection(cells)
     hu = _cy.uncompact_cells(hc, res)

--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -755,3 +755,13 @@ def test_construct_cell_inverses_int_api():
 def test_center_child_with_deconstruct():
     for h in h3.get_res0_cells():
         h3.construct_cell(*h3.deconstruct_cell(h), 0) == h3.cell_to_center_child(h)
+
+
+def test_uncompact_cells_invalid_resolution():
+    # Create a valid cell at resolution 5
+    h_res5 = h3.latlng_to_cell(0, 0, 5)
+
+    # Attempting to uncompact to a coarser resolution (4)
+    # should raise an H3ResDomainError
+    with pytest.raises(H3ResDomainError):
+        h3.uncompact_cells({h_res5}, 4)

--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -762,6 +762,6 @@ def test_uncompact_cells_invalid_resolution():
     h_res5 = h3.latlng_to_cell(0, 0, 5)
 
     # Attempting to uncompact to a coarser resolution (4)
-    # should raise an H3ResDomainError
+    # should raise an H3ResMismatchError
     with pytest.raises(H3ResMismatchError):
         h3.uncompact_cells({h_res5}, 4)

--- a/tests/test_lib/test_cells_and_edges.py
+++ b/tests/test_lib/test_cells_and_edges.py
@@ -763,5 +763,5 @@ def test_uncompact_cells_invalid_resolution():
 
     # Attempting to uncompact to a coarser resolution (4)
     # should raise an H3ResDomainError
-    with pytest.raises(H3ResDomainError):
+    with pytest.raises(H3ResMismatchError):
         h3.uncompact_cells({h_res5}, 4)


### PR DESCRIPTION
### Description
This PR resolves a TODO comment left in `uncompact_cells` regarding missing test coverage. 

I removed the TODO from `src\h3\api\basic_int\__init__.py` and added a test in `tests/test_lib/test_cells_and_edges.py` to verify that `H3ResMismatchError` is correctly raised when a user attempts to uncompact a cell into a coarser resolution.

### Maintainers
cc: @dfellis @ajfriend