### PR TITLE
Add CI test and build for python3.14t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-22.04]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -80,6 +80,9 @@ jobs:
           - os: windows-11-arm
             build: 'cp314-win_arm64'
             name: Windows ARM64 3.14
+          - os: windows-11-arm
+            build: 'cp314t-win_arm64'
+            name: Windows ARM64 3.14t
 
           - os: ubuntu-22.04
             build: 'cp*-manylinux_x86_64'
@@ -100,6 +103,9 @@ jobs:
           - os: ubuntu-22.04
             build: 'cp314-musllinux_x86_64'
             name: Linux Intel musl 64-bit 3.14
+          - os: ubuntu-22.04
+            build: 'cp314t-musllinux_x86_64'
+            name: Linux Intel musl 64-bit 3.14t
 
           - os: ubuntu-22.04
             build: 'cp310-manylinux_aarch64'
@@ -116,6 +122,9 @@ jobs:
           - os: ubuntu-22.04
             build: 'cp314-manylinux_aarch64'
             name: Linux Aarch64 3.14
+          - os: ubuntu-22.04
+            build: 'cp314t-manylinux_aarch64'
+            name: Linux Aarch64 3.14t
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
#493 fixed issue with free-threading `python`. This is to explicitly include free threading (`3.14t`) to both CI tests and builds. 