### PR TITLE
Raise ValueError instead of assert in geo_to_h3shape

### DIFF
--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -301,7 +301,11 @@ def geo_to_h3shape(geo):
         # get dict
         geo = geo.__geo_interface__
 
-    assert isinstance(geo, dict)  # todo: remove
+    if not isinstance(geo, dict):
+        raise ValueError(
+            'geo must be a dict or implement __geo_interface__, got: '
+            + str(type(geo))
+        )
 
     t = geo['type']
     coord = geo['coordinates']

--- a/tests/test_lib/polyfill/test_h3.py
+++ b/tests/test_lib/polyfill/test_h3.py
@@ -302,6 +302,11 @@ def test_geo_to_h3shape_passthrough():
         assert h3.geo_to_h3shape(shape) is shape
 
 
+def test_geo_to_h3shape_rejects_non_dict():
+    with pytest.raises(ValueError, match='dict or implement __geo_interface__'):
+        h3.geo_to_h3shape('not a geo object')
+
+
 def test_polyfill_down_under():
     sydney = [
         (-33.8556, 151.1979),


### PR DESCRIPTION
## Summary
geo_to_h3shape still used assert isinstance(geo, dict), which Bandit flags and which was already marked for removal.

This raises ValueError for invalid inputs instead, matching nearby validation style, and adds a unit test for the rejection path.

Fixes #498

## Test plan
1. Run the polyfill test_h3 suite filtered to geo_to_h3shape cases.
2. Confirm the existing geo conversion cases and the new rejection case pass.