### PR TITLE
fix: replace geo input assert with ValueError and add test

### DIFF
--- a/src/h3/_h3shape.py
+++ b/src/h3/_h3shape.py
@@ -301,7 +301,8 @@ def geo_to_h3shape(geo):
         # get dict
         geo = geo.__geo_interface__
 
-    assert isinstance(geo, dict)  # todo: remove
+    if not isinstance(geo, dict):
+        raise ValueError(f"Expected a dict or an object with __geo_interface__, but got: {type(geo).__name__}")
 
     t = geo['type']
     coord = geo['coordinates']

--- a/tests/test_lib/polyfill/test_polyfill.py
+++ b/tests/test_lib/polyfill/test_polyfill.py
@@ -151,6 +151,9 @@ def test_bad_geo_input():
     with pytest.raises(ValueError):
         h3.geo_to_cells({'type': 'not a shape', 'coordinates': None}, 9)
 
+    with pytest.raises(ValueError):
+        h3.geo_to_cells('not a shape', 9)
+
 
 def test_cells_to_geo():
     h = '89754e64993ffff'
@@ -166,17 +169,3 @@ def test_cells_to_geo():
     assert coord[0][0] == coord[0][-1]
 
     assert h3.geo_to_cells(geo, res) == [h]
-
-def test_bad_geo_input():
-    with pytest.raises(ValueError):
-        h3.h3shape_to_cells('not a shape', 9)
-
-    with pytest.raises(ValueError):
-        h3.h3shape_to_cells_experimental('not a shape', res=9)
-
-    with pytest.raises(ValueError):
-        h3.geo_to_cells({'type': 'not a shape', 'coordinates': None}, 9)
-
-    # Add this new block to test our specific fix!
-    with pytest.raises(ValueError):
-        h3.geo_to_cells('not a shape', 9)

--- a/tests/test_lib/polyfill/test_polyfill.py
+++ b/tests/test_lib/polyfill/test_polyfill.py
@@ -166,3 +166,17 @@ def test_cells_to_geo():
     assert coord[0][0] == coord[0][-1]
 
     assert h3.geo_to_cells(geo, res) == [h]
+
+def test_bad_geo_input():
+    with pytest.raises(ValueError):
+        h3.h3shape_to_cells('not a shape', 9)
+
+    with pytest.raises(ValueError):
+        h3.h3shape_to_cells_experimental('not a shape', res=9)
+
+    with pytest.raises(ValueError):
+        h3.geo_to_cells({'type': 'not a shape', 'coordinates': None}, 9)
+
+    # Add this new block to test our specific fix!
+    with pytest.raises(ValueError):
+        h3.geo_to_cells('not a shape', 9)


### PR DESCRIPTION
### Description
This PR resolves a lingering `todo` comment in `src/h3/_h3shape.py`. 

The `geo_to_h3shape` function contained a debug assertion (`assert isinstance(geo, dict)  # todo: remove`) that was explicitly marked for removal. 

To improve robustness, I replaced the raw assertion with a proper `ValueError` check to prevent confusing `TypeError` crashes if a user accidentally passes a string. I also added a unit test to `test_polyfill.py` to ensure this specific bad input is caught correctly.

### Maintainers
cc: @dfellis @ajfriend @isaacbrodsky